### PR TITLE
【API設計】ユーザ・プロフィール・履歴機能の設計書追加

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -42,6 +42,8 @@ paths:
                   type: string
                 birthday:
                   type: string
+                  format: date
+                  description: ユーザの誕生日(YYYY-MM-DD)
       responses:
         "200":
           description: 登録成功
@@ -144,6 +146,89 @@ paths:
                     description: ログアウトに成功した場合に返されるメッセージ
         "401":
           description: ログアウト失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
+      security:
+        - firebase: []
+  /profile:
+    get:
+      tags:
+        - profile
+      summary: ユーザプロフィール取得
+      description: ユーザーのプロフィールを取得する
+      parameters: []
+      responses:
+        "200":
+          description: プロフィール取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                    description: ユーザーID
+                  name:
+                    type: string
+                    description: ユーザー名
+                  birthday:
+                    type: string
+                    format: date
+                    description: ユーザーの誕生日(YYYY-MM-DD)
+        "401":
+          description: プロフィール取得失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
+      security:
+        - firebase: []
+    put:
+      tags:
+        - profile
+      summary: ユーザプロフィール更新
+      description: ユーザーのプロフィールを更新する
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                token:
+                  type: string
+                name:
+                  type: string
+                birthday:
+                  type: string
+                  format: date
+                  description: ユーザの誕生日(YYYY-MM-DD)
+      responses:
+        "200":
+          description: プロフィール更新成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: プロフィール更新に成功した場合に返されるメッセージ
+        "401":
+          description: プロフィール更新失敗
           content:
             application/json:
               schema:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -15,6 +15,57 @@ components:
       name: Authorization
       description: Firebaseのトークンを指定してください
 paths:
+  /sign_up:
+    post:
+      tags:
+        - auth
+      summary: 新規登録
+      description: ユーザーを新規登録する
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  enum: [email, google]
+                email:
+                  type: string
+                password:
+                  type: string
+                token:
+                  type: string
+                name:
+                  type: string
+                birthday:
+                  type: string
+      responses:
+        "200":
+          description: 登録成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                    description: 登録されたユーザーID
+                  token:
+                    type: string
+                    description: 登録に成功した場合に返されるトークン
+        "401":
+          description: 登録失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
   /sign_in:
     post:
       tags:
@@ -31,8 +82,8 @@ paths:
               properties:
                 provider:
                   type: string
-                  enum: [e-mail, google]
-                e-mail:
+                  enum: [email, google]
+                email:
                   type: string
                 password:
                   type: string
@@ -62,4 +113,44 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
-      security: []
+  /sign_out:
+    post:
+      tags:
+        - auth
+      summary: ログアウト
+      description: ログアウトする
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "200":
+          description: ログアウト成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: ログアウトに成功した場合に返されるメッセージ
+        "401":
+          description: ログアウト失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
+      security:
+        - firebase: []

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1,0 +1,65 @@
+openapi: 3.0.0
+info:
+  title: ホントくんAPI
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+    description: ローカル開発環境
+  - url: https://hontokun-backend.kouxi.jp
+    description: 本番環境
+components:
+  securitySchemes:
+    firebase:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Firebaseのトークンを指定してください
+paths:
+  /sign_in:
+    post:
+      tags:
+        - auth
+      summary: ログイン
+      description: Firebaseのトークンを受け取り、ユーザーを認証する
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  enum: [e-mail, google]
+                e-mail:
+                  type: string
+                password:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "200":
+          description: ログイン成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                    description: 認証されたユーザーID
+                  token:
+                    type: string
+                    description: ログインに成功した場合に返されるトークン
+        "401":
+          description: 認証失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
+      security: []

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -33,6 +33,35 @@ components:
           description: ユーザーの誕生日(YYYY-MM-DD)
       required:
         - name
+    UserStatus:
+      type: object
+      properties:
+        level:
+          type: integer
+          description: ユーザーのレベル
+        experience:
+          type: integer
+          description: ユーザーの経験値
+    CharacterImage:
+      type: object
+      properties:
+        character_image_id:
+          type: string
+          description: ユーザーの着せ替え画像のID
+    CharacterImages:
+      type: object
+      properties:
+        character_image_id_list:
+          type: array
+          items:
+            type: string
+          description: ユーザーの着せ替え画像のIDの配列
+    CharacterDialogue:
+      type: object
+      properties:
+        character_dialogue:
+          type: string
+          description: キャラクターのセリフ
 paths:
   /sign_up:
     post:
@@ -66,22 +95,80 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
-  /profile:
+  /home:
     get:
       tags:
-        - profile
-      summary: ユーザプロフィール取得
-      description: ユーザーのプロフィールを取得する
+        - home
+      summary: ホーム画面でのデータ取得
+      description: ユーザ情報を取得する
       parameters: []
       responses:
         "200":
-          description: プロフィール取得成功
+          description: ホーム画面データ取得成功
           content:
             application/json:
               schema:
                 allOf:
                   - $ref: "#/components/schemas/UserId"
                   - $ref: "#/components/schemas/UserProfile"
+                  - $ref: "#/components/schemas/UserStatus"
+                  - $ref: "#/components/schemas/CharacterImages"
+                  - $ref: "#/components/schemas/CharacterDialogue"
+                  - type: object
+                    properties:
+                      history:
+                        type: object
+                        properties:
+                          total_accuracy:
+                            type: number
+                            format: double
+                            description: ユーザーの総正答率
+                          quiz_set_list:
+                            type: array
+                            description: クイズのセット別の一覧
+                            items:
+                              type: object
+                              properties:
+                                quiz_set_id:
+                                  type: string
+                                  description: クイズセットのID
+                                quiz_set_difficulty:
+                                  type: integer
+                                  description: クイズの難易度
+                                  example: 1
+                                quiz_set_accuracy:
+                                  type: number
+                                  format: double
+                                  description: クイズのセット別の正答率
+                                  example: 0.67
+                                answered_at:
+                                  type: string
+                                  format: date-time
+                                  description: クイズを解いた日時
+                                quiz_set:
+                                  type: array
+                                  description: クイズセットの問題一覧
+                                  items:
+                                    type: object
+                                    properties:
+                                      quiz_id:
+                                        type: string
+                                        description: クイズのID
+                                      quiz_type:
+                                        type: string
+                                        description: クイズの出題形式（バトルかタイムアタックか）
+                                        example: "battle"
+                                      answer_time:
+                                        type: integer
+                                        nullable: true
+                                        description: クイズを解いた時間(タイムアタックの場合・秒)
+                                        example: 30
+                                      is_correct:
+                                        type: boolean
+                                        description: クイズの正誤
+                                      user_answer:
+                                        type: string
+                                        description: ユーザーの解答内容
                   - type: object
                     properties:
                       message:
@@ -99,6 +186,7 @@ paths:
                     description: エラーメッセージ
       security:
         - bearerAuth: []
+  /profile:
     put:
       tags:
         - profile
@@ -110,7 +198,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserProfile"
+              allOf:
+                - $ref: "#/components/schemas/UserProfile"
+                - $ref: "#/components/schemas/CharacterImage"
       responses:
         "200":
           description: プロフィール更新成功
@@ -120,6 +210,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/UserId"
                   - $ref: "#/components/schemas/UserProfile"
+                  - $ref: "#/components/schemas/CharacterImage"
                   - type: object
                     properties:
                       message:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -53,7 +53,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserId"
+                allOf:
+                  - $ref: "#/components/schemas/UserId"
+                  - $ref: "#/components/schemas/UserProfile"
         "401":
           description: 登録失敗
           content:
@@ -77,7 +79,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserProfile"
+                allOf:
+                  - $ref: "#/components/schemas/UserId"
+                  - $ref: "#/components/schemas/UserProfile"
+                  - type: object
+                    properties:
+                      message:
+                        type: string
+                        description: プロフィール取得に成功した場合に返されるメッセージ
         "401":
           description: プロフィール取得失敗
           content:
@@ -108,11 +117,14 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: プロフィール更新に成功した場合に返されるメッセージ
+                allOf:
+                  - $ref: "#/components/schemas/UserId"
+                  - $ref: "#/components/schemas/UserProfile"
+                  - type: object
+                    properties:
+                      message:
+                        type: string
+                        description: プロフィール更新に成功した場合に返されるメッセージ
         "401":
           description: プロフィール更新失敗
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -9,54 +9,30 @@ servers:
     description: 本番環境
 components:
   securitySchemes:
-    firebase:
-      type: apiKey
-      in: header
-      name: Authorization
-      description: Firebaseのトークンを指定してください
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWTを使用した認証を行います。`Authorization`ヘッダーに`Bearer`スキームでトークンを含めてください。
   schemas:
-    TokenRequest:
-      type: object
-      properties:
-        token:
-          type: string
-          description: Firebaseのトークン
-        provider:
-          type: string
-          enum: [email, google]
     UserId:
       type: object
       properties:
         user_id:
           type: string
           description: ユーザーID
-    UserEmail:
-      type: object
-      properties:
-        email:
-          type: string
-          format: email
-          description: ユーザーのメールアドレス
-    UserPassword:
-      type: object
-      properties:
-        password:
-          type: string
-          description: ユーザーのパスワード
     UserProfile:
-      allOf:
-        - $ref: "#/components/schemas/UserId"
-        - type: object
-          properties:
-            name:
-              type: string
-              description: ユーザー名
-            birthday:
-              type: string
-              format: date
-              description: ユーザーの誕生日(YYYY-MM-DD)
-          required:
-            - name
+      type: object
+      properties:
+        nickname:
+          type: string
+          description: ユーザー名
+        birthday:
+          type: string
+          format: date
+          description: ユーザーの誕生日(YYYY-MM-DD)
+      required:
+        - name
 paths:
   /sign_up:
     post:
@@ -70,20 +46,14 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: "#/components/schemas/UserId"
-                - $ref: "#/components/schemas/UserPassword"
-                - $ref: "#/components/schemas/TokenRequest"
-                - $ref: "#/components/schemas/UserProfile"
+              $ref: "#/components/schemas/UserProfile"
       responses:
         "200":
           description: 登録成功
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/UserId"
-                  - $ref: "#/components/schemas/TokenRequest"
+                $ref: "#/components/schemas/UserId"
         "401":
           description: 登録失敗
           content:
@@ -94,80 +64,6 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
-  /sign_in:
-    post:
-      tags:
-        - auth
-      summary: ログイン
-      description: Firebaseのトークンを受け取り、ユーザーを認証する
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: "#/components/schemas/TokenRequest"
-                - $ref: "#/components/schemas/UserId"
-                - $ref: "#/components/schemas/UserEmail"
-                - $ref: "#/components/schemas/UserPassword"
-      responses:
-        "200":
-          description: ログイン成功
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/UserId"
-                  - $ref: "#/components/schemas/TokenRequest"
-        "401":
-          description: 認証失敗
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
-  /sign_out:
-    post:
-      tags:
-        - auth
-      summary: ログアウト
-      description: ログアウトする
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              allOf:
-                - $ref: "#/components/schemas/UserId"
-                - $ref: "#/components/schemas/TokenRequest"
-      responses:
-        "200":
-          description: ログアウト成功
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: ログアウトに成功した場合に返されるメッセージ
-        "401":
-          description: ログアウト失敗
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
-      security:
-        - firebase: []
   /profile:
     get:
       tags:
@@ -193,7 +89,7 @@ paths:
                     type: string
                     description: エラーメッセージ
       security:
-        - firebase: []
+        - bearerAuth: []
     put:
       tags:
         - profile
@@ -205,9 +101,7 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: "#/components/schemas/TokenRequest"
-                - $ref: "#/components/schemas/UserProfile"
+              $ref: "#/components/schemas/UserProfile"
       responses:
         "200":
           description: プロフィール更新成功
@@ -230,4 +124,4 @@ paths:
                     type: string
                     description: エラーメッセージ
       security:
-        - firebase: []
+        - bearerAuth: []

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -135,12 +135,16 @@ paths:
                                 quiz_set_difficulty:
                                   type: integer
                                   description: クイズの難易度
-                                  example: 1
                                 quiz_set_accuracy:
                                   type: number
                                   format: double
                                   description: クイズのセット別の正答率
-                                  example: 0.67
+                                mode:
+                                  type: string
+                                  enum:
+                                    - "battle"
+                                    - "time_attack"
+                                  description: クイズの出題形式（バトルかタイムアタックか）
                                 answered_at:
                                   type: string
                                   format: date-time
@@ -154,26 +158,78 @@ paths:
                                       quiz_id:
                                         type: string
                                         description: クイズのID
+                                      news_title:
+                                        type: string
+                                        description: クイズのニュースのタイトル
+                                      news_content:
+                                        type: string
+                                        description: クイズのニュースの内容
+                                      news_image:
+                                        type: string
+                                        description: クイズのニュースの画像
+                                      question:
+                                        type: string
+                                        description: クイズの問題文
                                       quiz_type:
                                         type: string
-                                        description: クイズの出題形式（バトルかタイムアタックか）
-                                        example: "battle"
+                                        enum:
+                                          - "true_or_false"
+                                          - "multiple_choice"
+                                        description: クイズの問題タイプ（マルバツか選択式か）
+                                      quiz_choices:
+                                        type: array
+                                        items:
+                                          type: string
+                                        description: クイズの選択肢
+                                        nullable: true
+                                      correct_answer:
+                                        type: string
+                                        description: クイズの正解
                                       answer_time:
                                         type: integer
                                         nullable: true
                                         description: クイズを解いた時間(タイムアタックの場合・秒)
-                                        example: 30
                                       is_correct:
                                         type: boolean
                                         description: クイズの正誤
                                       user_answer:
                                         type: string
                                         description: ユーザーの解答内容
-                  - type: object
-                    properties:
-                      message:
-                        type: string
-                        description: プロフィール取得に成功した場合に返されるメッセージ
+                                      explanation:
+                                        type: string
+                                        description: クイズの解説
+              example:
+                user_id: "1"
+                nickname: "ホントくん"
+                level: 2
+                experience: 4
+                character_image_id_list: ["1", "2"]
+                character_dialogue: |
+                  ようこそ！
+                  $USER_NAME  探偵事務所へ
+                  僕は助手のホントくん
+                  よろしくね！"
+                history:
+                  total_accuracy: 0.5
+                  quiz_set_list:
+                    - quiz_set_id: "1"
+                      quiz_set_difficulty: 1
+                      quiz_set_accuracy: 0.5
+                      mode: "battle"
+                      answered_at: "2021-01-01T00:00:00Z"
+                      quiz_set:
+                        - quiz_id: "1"
+                          news_title: "台風15号接近 首都圏厳戒態勢"
+                          news_content: "台風15号が関東地方に接近中。気象庁は警戒を呼びかけ、各地で厳重な備えが進む。東京都は午後から公共交通機関の計画運休を発表。スーパーには買い出しの長蛇の列。企業は在宅勤務を推奨し、学校は休校を決定。避難所も開設され始めた。強風と豪雨に備え、住民の緊張が高まる。明日未明に最接近の見込み。"
+                          news_image: "https://example.com/image.jpg"
+                          question: "これはフェイク？"
+                          quiz_type: "true_or_false"
+                          quiz_choices: null
+                          correct_answer: "true"
+                          answer_time: 30
+                          is_correct: true
+                          user_answer: "true"
+                          explanation: "この問題は実際にあったニュースです"
         "401":
           description: プロフィール取得失敗
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -14,6 +14,49 @@ components:
       in: header
       name: Authorization
       description: Firebaseのトークンを指定してください
+  schemas:
+    TokenRequest:
+      type: object
+      properties:
+        token:
+          type: string
+          description: Firebaseのトークン
+        provider:
+          type: string
+          enum: [email, google]
+    UserId:
+      type: object
+      properties:
+        user_id:
+          type: string
+          description: ユーザーID
+    UserEmail:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          description: ユーザーのメールアドレス
+    UserPassword:
+      type: object
+      properties:
+        password:
+          type: string
+          description: ユーザーのパスワード
+    UserProfile:
+      allOf:
+        - $ref: "#/components/schemas/UserId"
+        - type: object
+          properties:
+            name:
+              type: string
+              description: ユーザー名
+            birthday:
+              type: string
+              format: date
+              description: ユーザーの誕生日(YYYY-MM-DD)
+          required:
+            - name
 paths:
   /sign_up:
     post:
@@ -27,37 +70,20 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                provider:
-                  type: string
-                  enum: [email, google]
-                email:
-                  type: string
-                password:
-                  type: string
-                token:
-                  type: string
-                name:
-                  type: string
-                birthday:
-                  type: string
-                  format: date
-                  description: ユーザの誕生日(YYYY-MM-DD)
+              allOf:
+                - $ref: "#/components/schemas/UserId"
+                - $ref: "#/components/schemas/UserPassword"
+                - $ref: "#/components/schemas/TokenRequest"
+                - $ref: "#/components/schemas/UserProfile"
       responses:
         "200":
           description: 登録成功
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  user_id:
-                    type: string
-                    description: 登録されたユーザーID
-                  token:
-                    type: string
-                    description: 登録に成功した場合に返されるトークン
+                allOf:
+                  - $ref: "#/components/schemas/UserId"
+                  - $ref: "#/components/schemas/TokenRequest"
         "401":
           description: 登録失敗
           content:
@@ -80,31 +106,20 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                provider:
-                  type: string
-                  enum: [email, google]
-                email:
-                  type: string
-                password:
-                  type: string
-                token:
-                  type: string
+              allOf:
+                - $ref: "#/components/schemas/TokenRequest"
+                - $ref: "#/components/schemas/UserId"
+                - $ref: "#/components/schemas/UserEmail"
+                - $ref: "#/components/schemas/UserPassword"
       responses:
         "200":
           description: ログイン成功
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  user_id:
-                    type: string
-                    description: 認証されたユーザーID
-                  token:
-                    type: string
-                    description: ログインに成功した場合に返されるトークン
+                allOf:
+                  - $ref: "#/components/schemas/UserId"
+                  - $ref: "#/components/schemas/TokenRequest"
         "401":
           description: 認証失敗
           content:
@@ -127,12 +142,9 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                user_id:
-                  type: string
-                token:
-                  type: string
+              allOf:
+                - $ref: "#/components/schemas/UserId"
+                - $ref: "#/components/schemas/TokenRequest"
       responses:
         "200":
           description: ログアウト成功
@@ -169,18 +181,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  user_id:
-                    type: string
-                    description: ユーザーID
-                  name:
-                    type: string
-                    description: ユーザー名
-                  birthday:
-                    type: string
-                    format: date
-                    description: ユーザーの誕生日(YYYY-MM-DD)
+                $ref: "#/components/schemas/UserProfile"
         "401":
           description: プロフィール取得失敗
           content:
@@ -204,18 +205,9 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                user_id:
-                  type: string
-                token:
-                  type: string
-                name:
-                  type: string
-                birthday:
-                  type: string
-                  format: date
-                  description: ユーザの誕生日(YYYY-MM-DD)
+              allOf:
+                - $ref: "#/components/schemas/TokenRequest"
+                - $ref: "#/components/schemas/UserProfile"
       responses:
         "200":
           description: プロフィール更新成功


### PR DESCRIPTION
## issue
- https://github.com/kouxi08/Hontokun-backend/issues/1

## 概要
- API設計書の作成
  - /sign_up
    - ユーザ作成
  - /home
    - プロフィール閲覧
    - 履歴
  - /profile
    - プロフィール更新