### PR TITLE
【API設計】履歴の取得の仕様を変更する

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -309,7 +309,7 @@ paths:
                       totalAccuracy:
                         $ref: "#/components/schemas/Accuracy"
                         description: ユーザの総正答率
-                      list:
+                      tierList:
                         type: array
                         description: 難易度別の一覧
                         items:
@@ -324,70 +324,11 @@ paths:
                             character:
                               $ref: "#/components/schemas/Images"
                               description: クイズセットの指名手配猫
-        "401":
-          description: 認証エラー
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UnauthorizedError"
-        "403":
-          description: アクセス拒否
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ForbiddenError"
-        "404":
-          description: リソースが見つかりません
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/NotFoundError"
-        "500":
-          description: サーバーエラー
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InternalServerError"
-      security:
-        - bearerAuth: []
-  /history/tier/{tier}:
-    get:
-      tags:
-        - history
-      summary: クイズ履歴難易度別取得
-      description: ユーザのクイズ履歴のリストを難易度別に取得する
-      parameters:
-        - name: tier
-          in: path
-          required: true
-          schema:
-            type: integer
-          description: クイズセットの難易度
-      responses:
-        "200":
-          description: クイズ履歴難易度別取得成功
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  character:
-                    $ref: "#/components/schemas/Images"
-                    description: クイズセットの指名手配猫
-                  totalAccuracy:
-                    $ref: "#/components/schemas/Accuracy"
-                    description: クイズセットの正答率
-                  quizSet:
-                    type: array
-                    description: クイズセットの一覧
-                    items:
-                      $ref: "#/components/schemas/QuizSet"
-        "400":
-          description: リクエストエラー
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BadRequestError"
+                            quizSetList:
+                              type: array
+                              description: クイズセットの一覧
+                              items:
+                                $ref: "#/components/schemas/QuizSet"
         "401":
           description: 認証エラー
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -634,7 +634,13 @@ paths:
                             type: array
                             description: クイズの問題一覧
                             items:
-                              $ref: "#/components/schemas/Quiz"
+                              allOf:
+                                - $ref: "#/components/schemas/Quiz"
+                                - type: object
+                                  properties:
+                                    hint:
+                                      type: string
+                                      description: クイズのヒント
 
         "400":
           description: リクエストエラー
@@ -708,7 +714,6 @@ paths:
                       allOf:
                         - $ref: "#/components/schemas/Quiz"
                         - $ref: "#/components/schemas/QuizAnswer"
-
         "400":
           description: リクエストエラー
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -18,7 +18,7 @@ components:
     UserId:
       type: object
       properties:
-        user_id:
+        id:
           type: string
           description: ユーザーID
     UserProfile:
@@ -45,13 +45,13 @@ components:
     CharacterImageId:
       type: object
       properties:
-        character_image_id:
+        id:
           type: string
           description: ユーザーの着せ替え画像のID
     CharacterImageUrl:
       type: object
       properties:
-        character_image_url:
+        url:
           type: string
           description: ユーザーの着せ替え画像のURL
     CharacterImage:
@@ -69,7 +69,7 @@ components:
     CharacterDialogue:
       type: object
       properties:
-        character_dialogue:
+        dialogue:
           type: string
           description: キャラクターのセリフ
     Quiz:
@@ -124,13 +124,13 @@ components:
     QuizSet:
       type: object
       properties:
-        quiz_set_id:
+        id:
           type: string
           description: クイズセットのID
-        quiz_set_difficulty:
+        difficulty:
           type: integer
-          description: クイズの難易度
-        quiz_set_accuracy:
+          description: クイズセットの難易度
+        accuracy:
           type: number
           format: double
           description: クイズのセット別の正答率
@@ -186,24 +186,29 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/UserId"
-                  - $ref: "#/components/schemas/UserProfile"
-                  - $ref: "#/components/schemas/UserStatus"
-                  - $ref: "#/components/schemas/CharacterDialogue"
-                  - $ref: "#/components/schemas/CharacterImageUrl"
-              example:
-                user_id: "1"
-                nickname: "ホントくん"
-                birthday: "2020-01-01"
-                level: 2
-                experience: 4
-                character_image_url: "https://example.com/image1.jpg"
-                character_dialogue: |
-                  ようこそ！
-                  $USER_NAME  探偵事務所へ
-                  僕は助手のホントくん
-                  よろしくね！"
+                type: object
+                properties:
+                  user:
+                    allOf:
+                      - $ref: "#/components/schemas/UserId"
+                      - $ref: "#/components/schemas/UserProfile"
+                      - $ref: "#/components/schemas/UserStatus"
+                  character:
+                    allOf:
+                      - $ref: "#/components/schemas/CharacterDialogue"
+                      - $ref: "#/components/schemas/CharacterImageUrl"
+              # example:
+              #   user_id: "1"
+              #   nickname: "ホントくん"
+              #   birthday: "2020-01-01"
+              #   level: 2
+              #   experience: 4
+              #   character_image_url: "https://example.com/image1.jpg"
+              #   character_dialogue: |
+              #     ようこそ！
+              #     $USER_NAME  探偵事務所へ
+              #     僕は助手のホントくん
+              #     よろしくね！"
         "401":
           description: プロフィール取得失敗
           content:
@@ -216,6 +221,55 @@ paths:
                     description: エラーメッセージ
       security:
         - bearerAuth: []
+  /history:
+    get:
+      tags:
+        - /history
+      summary: クイズ履歴取得
+      description: ユーザのクイズ履歴を取得する
+      parameters: []
+      responses:
+        "200":
+          description: クイズ履歴取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user:
+                    allOf:
+                      # ユーザのID, name, キャラクター
+                      - $ref: "#/components/schemas/UserId"
+                      - $ref: "#/components/schemas/UserProfile"
+                      - type: object
+                        properties:
+                          character:
+                            $ref: "#/components/schemas/CharacterImage"
+                            description: ユーザの着せ替え画像
+                    description: ユーザのステータス
+                  history:
+                    type: object
+                    properties:
+                      total_accuracy:
+                        type: number
+                        format: double
+                        description: ユーザの総正答率
+                      quiz_set:
+                        type: array
+                        description: クイズのセット別の一覧
+                        items:
+                          $ref: "#/components/schemas/QuizSet"
+
+        "401":
+          description: クイズ履歴取得失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
   /profile:
     put:
       tags:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -61,7 +61,7 @@ components:
     CharacterImageList:
       type: object
       properties:
-        character_image_list:
+        imageList:
           type: array
           items:
             $ref: "#/components/schemas/CharacterImage"
@@ -113,20 +113,20 @@ components:
             type: string
           description: クイズの選択肢
           nullable: true
-        correct_answer:
+        correctAnswer:
           type: string
           description: クイズの正解
-    QuizUserAnswer:
+    QuizAnswer:
       type: object
       properties:
-        answer_time:
+        answerTime:
           type: integer
           nullable: true
           description: クイズを解いた時間(タイムアタックの場合・秒)
-        is_correct:
+        isCorrect:
           type: boolean
           description: クイズの正誤
-        user_answer:
+        userAnswer:
           type: string
           description: ユーザーの解答内容
         explanation:
@@ -148,12 +148,12 @@ components:
             - "battle"
             - "time_attack"
           description: クイズの出題形式（バトルかタイムアタックか）
-        answered_at:
+        answeredAt:
           type: string
           format: date-time
           description: クイズセットを解いた日時
 paths:
-  /sign_up:
+  /sign-up:
     post:
       tags:
         - auth
@@ -231,8 +231,6 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
-      security:
-        - bearerAuth: []
   /history:
     get:
       tags:
@@ -261,7 +259,7 @@ paths:
                   history:
                     type: object
                     properties:
-                      total_accuracy:
+                      totalAccuracy:
                         type: number
                         format: double
                         description: ユーザの総正答率
@@ -291,6 +289,8 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
+      security:
+        - bearerAuth: []
   /history/tier/{tier}:
     get:
       tags:
@@ -312,15 +312,20 @@ paths:
               schema:
                 type: object
                 properties:
-                  total_accuracy:
+                  character:
+                    $ref: "#/components/schemas/WantedCat"
+                    description: クイズセットの指名手配猫
+                  totalAccuracy:
                     type: number
                     format: double
                     description: クイズセットの正答率
-                  quiz_set:
+                  quizSet:
                     type: array
                     description: クイズセットの一覧
                     items:
                       $ref: "#/components/schemas/QuizSet"
+      security:
+        - bearerAuth: []
   /history/quiz-set/{quizSetId}:
     get:
       tags:
@@ -345,7 +350,7 @@ paths:
                   character:
                     $ref: "#/components/schemas/WantedCat"
                     description: クイズセットの指名手配猫
-                  quiz_set:
+                  quizSet:
                     $ref: "#/components/schemas/QuizSet"
                   quizzes:
                     type: array
@@ -353,8 +358,9 @@ paths:
                     items:
                       allOf:
                         - $ref: "#/components/schemas/Quiz"
-                        - $ref: "#/components/schemas/QuizUserAnswer"
-
+                        - $ref: "#/components/schemas/QuizAnswer"
+      security:
+        - bearerAuth: []
   /profile:
     put:
       tags:
@@ -381,7 +387,7 @@ paths:
                   - $ref: "#/components/schemas/UserProfile"
                   - type: object
                     properties:
-                      character_image:
+                      characterImage:
                         $ref: "#/components/schemas/CharacterImage"
                       message:
                         type: string

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -48,14 +48,16 @@ components:
         character_image_id:
           type: string
           description: ユーザーの着せ替え画像のID
+    CharacterImageUrl:
+      type: object
+      properties:
+        character_image_url:
+          type: string
+          description: ユーザーの着せ替え画像のURL
     CharacterImage:
       allOf:
         - $ref: "#/components/schemas/CharacterImageId"
-        - type: object
-          properties:
-            character_image_url:
-              type: string
-              description: ユーザーの着せ替え画像のURL
+        - $ref: "#/components/schemas/CharacterImageUrl"
     CharacterImageList:
       type: object
       properties:
@@ -176,7 +178,7 @@ paths:
       tags:
         - home
       summary: ホーム画面でのデータ取得
-      description: ユーザ情報を取得する
+      description: ユーザのステータスや着せ替えを取得する
       parameters: []
       responses:
         "200":
@@ -188,84 +190,20 @@ paths:
                   - $ref: "#/components/schemas/UserId"
                   - $ref: "#/components/schemas/UserProfile"
                   - $ref: "#/components/schemas/UserStatus"
-                  - $ref: "#/components/schemas/CharacterImageList"
                   - $ref: "#/components/schemas/CharacterDialogue"
-                  - type: object
-                    properties:
-                      current_character_image:
-                        $ref: "#/components/schemas/CharacterImage"
-                        description: ユーザーが選択中の着せ替え画像
-                      history:
-                        type: object
-                        properties:
-                          total_accuracy:
-                            type: number
-                            format: double
-                            description: ユーザーの総正答率
-                          quiz_set_list:
-                            type: array
-                            description: クイズのセット別の一覧
-                            items:
-                              allOf:
-                                - $ref: "#/components/schemas/QuizSet"
-                                - type: object
-                                  properties:
-                                    answered_at:
-                                      type: string
-                                      format: date-time
-                                      description: クイズを解いた日時
-                                    quiz_set:
-                                      type: array
-                                      description: クイズセットの問題一覧
-                                      items:
-                                        allOf:
-                                          - $ref: "#/components/schemas/Quiz"
-                                          - $ref: "#/components/schemas/QuizUserAnswer"
+                  - $ref: "#/components/schemas/CharacterImageUrl"
               example:
                 user_id: "1"
                 nickname: "ホントくん"
+                birthday: "2020-01-01"
                 level: 2
                 experience: 4
-                current_character_image:
-                  character_image_id: "1"
-                  character_image_url: "https://example.com/image1.jpg"
-                character_image_list:
-                  [
-                    {
-                      character_image_id: "2",
-                      character_image_url: "https://example.com/image2.jpg",
-                    },
-                    {
-                      character_image_id: "3",
-                      character_image_url: "https://example.com/image3.jpg",
-                    },
-                  ]
+                character_image_url: "https://example.com/image1.jpg"
                 character_dialogue: |
                   ようこそ！
                   $USER_NAME  探偵事務所へ
                   僕は助手のホントくん
                   よろしくね！"
-                history:
-                  total_accuracy: 0.5
-                  quiz_set_list:
-                    - quiz_set_id: "1"
-                      quiz_set_difficulty: 1
-                      quiz_set_accuracy: 0.5
-                      mode: "battle"
-                      answered_at: "2021-01-01T00:00:00Z"
-                      quiz_set:
-                        - quiz_id: "1"
-                          news_title: "台風15号接近 首都圏厳戒態勢"
-                          news_content: "台風15号が関東地方に接近中。気象庁は警戒を呼びかけ、各地で厳重な備えが進む。東京都は午後から公共交通機関の計画運休を発表。スーパーには買い出しの長蛇の列。企業は在宅勤務を推奨し、学校は休校を決定。避難所も開設され始めた。強風と豪雨に備え、住民の緊張が高まる。明日未明に最接近の見込み。"
-                          news_image: "https://example.com/image.jpg"
-                          question: "これはフェイク？"
-                          quiz_type: "true_or_false"
-                          quiz_choices: null
-                          correct_answer: "true"
-                          answer_time: 30
-                          is_correct: true
-                          user_answer: "true"
-                          explanation: "この問題は実際にあったニュースです"
         "401":
           description: プロフィール取得失敗
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -625,11 +625,17 @@ paths:
                   characterImage:
                     $ref: "#/components/schemas/CharacterImage"
                     description: クイズセットの指名手配猫
-                  quizSetList:
-                    type: array
-                    description: クイズのセット別の一覧
-                    items:
-                      $ref: "#/components/schemas/QuizSet"
+                  quizSet:
+                    allOf:
+                      - $ref: "#/components/schemas/QuizSet"
+                      - type: object
+                        properties:
+                          quizList:
+                            type: array
+                            description: クイズの問題一覧
+                            items:
+                              $ref: "#/components/schemas/Quiz"
+
         "400":
           description: リクエストエラー
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -42,26 +42,102 @@ components:
         experience:
           type: integer
           description: ユーザーの経験値
-    CharacterImage:
+    CharacterImageId:
       type: object
       properties:
         character_image_id:
           type: string
           description: ユーザーの着せ替え画像のID
-    CharacterImages:
+    CharacterImage:
+      allOf:
+        - $ref: "#/components/schemas/CharacterImageId"
+        - type: object
+          properties:
+            character_image_url:
+              type: string
+              description: ユーザーの着せ替え画像のURL
+    CharacterImageList:
       type: object
       properties:
-        character_image_id_list:
+        character_image_list:
           type: array
           items:
-            type: string
-          description: ユーザーの着せ替え画像のIDの配列
+            $ref: "#/components/schemas/CharacterImage"
+          description: ユーザーが所持する着せ替えの一覧（選択中は除く）
     CharacterDialogue:
       type: object
       properties:
         character_dialogue:
           type: string
           description: キャラクターのセリフ
+    Quiz:
+      type: object
+      properties:
+        quiz_id:
+          type: string
+          description: クイズのID
+        news_title:
+          type: string
+          description: クイズのニュースのタイトル
+        news_content:
+          type: string
+          description: クイズのニュースの内容
+        news_image:
+          type: string
+          description: クイズのニュースの画像
+        question:
+          type: string
+          description: クイズの問題文
+        quiz_type:
+          type: string
+          enum:
+            - "true_or_false"
+            - "multiple_choice"
+          description: クイズの問題タイプ（マルバツか選択式か）
+        quiz_choices:
+          type: array
+          items:
+            type: string
+          description: クイズの選択肢
+          nullable: true
+        correct_answer:
+          type: string
+          description: クイズの正解
+    QuizUserAnswer:
+      type: object
+      properties:
+        answer_time:
+          type: integer
+          nullable: true
+          description: クイズを解いた時間(タイムアタックの場合・秒)
+        is_correct:
+          type: boolean
+          description: クイズの正誤
+        user_answer:
+          type: string
+          description: ユーザーの解答内容
+        explanation:
+          type: string
+          description: クイズの解説
+    QuizSet:
+      type: object
+      properties:
+        quiz_set_id:
+          type: string
+          description: クイズセットのID
+        quiz_set_difficulty:
+          type: integer
+          description: クイズの難易度
+        quiz_set_accuracy:
+          type: number
+          format: double
+          description: クイズのセット別の正答率
+        mode:
+          type: string
+          enum:
+            - "battle"
+            - "time_attack"
+          description: クイズの出題形式（バトルかタイムアタックか）
 paths:
   /sign_up:
     post:
@@ -112,10 +188,13 @@ paths:
                   - $ref: "#/components/schemas/UserId"
                   - $ref: "#/components/schemas/UserProfile"
                   - $ref: "#/components/schemas/UserStatus"
-                  - $ref: "#/components/schemas/CharacterImages"
+                  - $ref: "#/components/schemas/CharacterImageList"
                   - $ref: "#/components/schemas/CharacterDialogue"
                   - type: object
                     properties:
+                      current_character_image:
+                        $ref: "#/components/schemas/CharacterImage"
+                        description: ユーザーが選択中の着せ替え画像
                       history:
                         type: object
                         properties:
@@ -127,83 +206,40 @@ paths:
                             type: array
                             description: クイズのセット別の一覧
                             items:
-                              type: object
-                              properties:
-                                quiz_set_id:
-                                  type: string
-                                  description: クイズセットのID
-                                quiz_set_difficulty:
-                                  type: integer
-                                  description: クイズの難易度
-                                quiz_set_accuracy:
-                                  type: number
-                                  format: double
-                                  description: クイズのセット別の正答率
-                                mode:
-                                  type: string
-                                  enum:
-                                    - "battle"
-                                    - "time_attack"
-                                  description: クイズの出題形式（バトルかタイムアタックか）
-                                answered_at:
-                                  type: string
-                                  format: date-time
-                                  description: クイズを解いた日時
-                                quiz_set:
-                                  type: array
-                                  description: クイズセットの問題一覧
-                                  items:
-                                    type: object
-                                    properties:
-                                      quiz_id:
-                                        type: string
-                                        description: クイズのID
-                                      news_title:
-                                        type: string
-                                        description: クイズのニュースのタイトル
-                                      news_content:
-                                        type: string
-                                        description: クイズのニュースの内容
-                                      news_image:
-                                        type: string
-                                        description: クイズのニュースの画像
-                                      question:
-                                        type: string
-                                        description: クイズの問題文
-                                      quiz_type:
-                                        type: string
-                                        enum:
-                                          - "true_or_false"
-                                          - "multiple_choice"
-                                        description: クイズの問題タイプ（マルバツか選択式か）
-                                      quiz_choices:
-                                        type: array
-                                        items:
-                                          type: string
-                                        description: クイズの選択肢
-                                        nullable: true
-                                      correct_answer:
-                                        type: string
-                                        description: クイズの正解
-                                      answer_time:
-                                        type: integer
-                                        nullable: true
-                                        description: クイズを解いた時間(タイムアタックの場合・秒)
-                                      is_correct:
-                                        type: boolean
-                                        description: クイズの正誤
-                                      user_answer:
-                                        type: string
-                                        description: ユーザーの解答内容
-                                      explanation:
-                                        type: string
-                                        description: クイズの解説
+                              allOf:
+                                - $ref: "#/components/schemas/QuizSet"
+                                - type: object
+                                  properties:
+                                    answered_at:
+                                      type: string
+                                      format: date-time
+                                      description: クイズを解いた日時
+                                    quiz_set:
+                                      type: array
+                                      description: クイズセットの問題一覧
+                                      items:
+                                        allOf:
+                                          - $ref: "#/components/schemas/Quiz"
+                                          - $ref: "#/components/schemas/QuizUserAnswer"
               example:
                 user_id: "1"
                 nickname: "ホントくん"
                 level: 2
                 experience: 4
-                character_image_id_list: ["1", "2"]
+                current_character_image:
+                  character_image_id: "1"
+                  character_image_url: "https://example.com/image1.jpg"
+                character_image_list:
+                  [
+                    {
+                      character_image_id: "2",
+                      character_image_url: "https://example.com/image2.jpg",
+                    },
+                    {
+                      character_image_id: "3",
+                      character_image_url: "https://example.com/image3.jpg",
+                    },
+                  ]
                 character_dialogue: |
                   ようこそ！
                   $USER_NAME  探偵事務所へ
@@ -256,7 +292,7 @@ paths:
             schema:
               allOf:
                 - $ref: "#/components/schemas/UserProfile"
-                - $ref: "#/components/schemas/CharacterImage"
+                - $ref: "#/components/schemas/CharacterImageId"
       responses:
         "200":
           description: プロフィール更新成功
@@ -266,9 +302,10 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/UserId"
                   - $ref: "#/components/schemas/UserProfile"
-                  - $ref: "#/components/schemas/CharacterImage"
                   - type: object
                     properties:
+                      character_image:
+                        $ref: "#/components/schemas/CharacterImage"
                       message:
                         type: string
                         description: プロフィール更新に成功した場合に返されるメッセージ
@@ -284,3 +321,41 @@ paths:
                     description: エラーメッセージ
       security:
         - bearerAuth: []
+  /quiz/{difficulty}:
+    get:
+      tags:
+        - quiz
+      summary: クイズの問題取得
+      description: クイズの問題を難易度別で取得する
+      parameters:
+        - name: difficulty
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: クイズの難易度
+      responses:
+        "200":
+          description: クイズ取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  character_image:
+                    $ref: "#/components/schemas/CharacterImage"
+                    description: ユーザーが選択中の着せ替え画像
+                  quiz_set_list:
+                    type: array
+                    description: クイズのセット別の一覧
+                    items:
+                      allOf:
+                        - $ref: "#/components/schemas/QuizSet"
+                        - type: object
+                          properties:
+                            quiz_set:
+                              type: array
+                              description: クイズセットの問題一覧
+                              items:
+                                allOf:
+                                  - $ref: "#/components/schemas/Quiz"

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -32,7 +32,7 @@ components:
           format: date
           description: ユーザーの誕生日(YYYY-MM-DD)
       required:
-        - name
+        - nickname
     UserStatus:
       type: object
       properties:
@@ -54,38 +54,38 @@ components:
         url:
           type: string
           description: キャラクター画像のURL
+    CharacterImageName:
+      type: object
+      properties:
+        name:
+          type: string
+          description: キャラクター画像の名前
     CharacterImage:
       allOf:
         - $ref: "#/components/schemas/CharacterImageId"
+        - $ref: "#/components/schemas/CharacterImageName"
         - $ref: "#/components/schemas/CharacterImageUrl"
-    CharacterImageList:
-      type: object
-      properties:
-        imageList:
-          type: array
-          items:
-            $ref: "#/components/schemas/CharacterImage"
-          description: ユーザーが所持する着せ替えの一覧（選択中は除く）
     CharacterDialogue:
       type: object
       properties:
         dialogue:
           type: string
           description: キャラクターのセリフ
-    WantedCat:
-      allOf:
-        - $ref: "#/components/schemas/CharacterImageUrl"
-        - type: object
-          properties:
-            name:
-              type: string
-              description: 指名手配猫の名前
+    Accuracy:
+      type: number
+      format: double
+      description: クイズセットの正答率
+    QuizId:
+      type: string
+      description: クイズのID
+    QuizSetId:
+      type: string
+      description: クイズセットのID
     Quiz:
       type: object
       properties:
         id:
-          type: string
-          description: クイズのID
+          $ref: "#/components/schemas/QuizId"
         news:
           type: object
           properties:
@@ -136,11 +136,9 @@ components:
       type: object
       properties:
         id:
-          type: string
-          description: クイズセットのID
+          $ref: "#/components/schemas/QuizSetId"
         accuracy:
-          type: number
-          format: double
+          $ref: "#/components/schemas/Accuracy"
           description: クイズセットの正答率
         mode:
           type: string
@@ -205,7 +203,7 @@ paths:
                       - $ref: "#/components/schemas/UserId"
                       - $ref: "#/components/schemas/UserProfile"
                       - $ref: "#/components/schemas/UserStatus"
-                  character:
+                  characterImage:
                     allOf:
                       - $ref: "#/components/schemas/CharacterDialogue"
                       - $ref: "#/components/schemas/CharacterImageUrl"
@@ -260,8 +258,7 @@ paths:
                     type: object
                     properties:
                       totalAccuracy:
-                        type: number
-                        format: double
+                        $ref: "#/components/schemas/Accuracy"
                         description: ユーザの総正答率
                       list:
                         type: array
@@ -273,11 +270,10 @@ paths:
                               type: integer
                               description: クイズセットの難易度
                             accuracy:
-                              type: number
-                              format: double
+                              $ref: "#/components/schemas/Accuracy"
                               description: クイズセットの正答率
-                            character:
-                              $ref: "#/components/schemas/WantedCat"
+                            characterImage:
+                              $ref: "#/components/schemas/CharacterImage"
                               description: クイズセットの指名手配猫
         "401":
           description: クイズ履歴取得失敗
@@ -313,11 +309,10 @@ paths:
                 type: object
                 properties:
                   character:
-                    $ref: "#/components/schemas/WantedCat"
+                    $ref: "#/components/schemas/CharacterImage"
                     description: クイズセットの指名手配猫
                   totalAccuracy:
-                    type: number
-                    format: double
+                    $ref: "#/components/schemas/Accuracy"
                     description: クイズセットの正答率
                   quizSet:
                     type: array
@@ -337,8 +332,7 @@ paths:
           in: path
           required: true
           schema:
-            type: string
-          description: クイズセットのID
+            $ref: "#/components/schemas/QuizSetId"
       responses:
         "200":
           description: クイズ履歴詳細取得成功
@@ -348,11 +342,11 @@ paths:
                 type: object
                 properties:
                   character:
-                    $ref: "#/components/schemas/WantedCat"
+                    $ref: "#/components/schemas/CharacterImage"
                     description: クイズセットの指名手配猫
                   quizSet:
                     $ref: "#/components/schemas/QuizSet"
-                  quizzes:
+                  quizList:
                     type: array
                     description: クイズの問題一覧
                     items:
@@ -362,6 +356,43 @@ paths:
       security:
         - bearerAuth: []
   /profile:
+    get:
+      tags:
+        - profile
+      summary: ユーザプロフィール取得
+      description: ユーザのプロフィールを取得する
+      parameters: []
+      responses:
+        "200":
+          description: プロフィール取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  profile:
+                    allOf:
+                      - $ref: "#/components/schemas/UserId"
+                      - $ref: "#/components/schemas/UserProfile"
+                      - type: object
+                        properties:
+                          character:
+                            $ref: "#/components/schemas/CharacterImage"
+                  characterOptions:
+                    type: array
+                    description: キャラクター画像の一覧
+                    items:
+                      $ref: "#/components/schemas/CharacterImage"
+        "401":
+          description: プロフィール取得失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ
     put:
       tags:
         - profile
@@ -375,7 +406,10 @@ paths:
             schema:
               allOf:
                 - $ref: "#/components/schemas/UserProfile"
-                - $ref: "#/components/schemas/CharacterImageId"
+                - type: object
+                  properties:
+                    characterId:
+                      $ref: "#/components/schemas/CharacterImageId/properties/id"
       responses:
         "200":
           description: プロフィール更新成功
@@ -425,20 +459,64 @@ paths:
               schema:
                 type: object
                 properties:
-                  character_image:
+                  characterImage:
                     $ref: "#/components/schemas/CharacterImage"
-                    description: ユーザーが選択中の着せ替え画像
-                  quiz_set_list:
+                    description: クイズセットの指名手配猫
+                  quizSetList:
                     type: array
                     description: クイズのセット別の一覧
                     items:
+                      $ref: "#/components/schemas/QuizSet"
+  /quiz/result:
+    post:
+      tags:
+        - quiz
+      summary: クイズの解答結果送信
+      description: クイズの解答結果を送信する
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                quizId:
+                  $ref: "#/components/schemas/QuizId"
+                answer:
+                  type: string
+                  description: ユーザーの解答
+                answerTime:
+                  type: integer
+                  nullable: true
+                  description: クイズを解いた時間(タイムアタックの場合・秒)
+      responses:
+        "200":
+          description: クイズ解答成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  quizSetId:
+                    $ref: "#/components/schemas/QuizSetId"
+                  accuracy:
+                    $ref: "#/components/schemas/Accuracy"
+                    description: クイズセットの正答率
+                  quizList:
+                    type: array
+                    items:
                       allOf:
-                        - $ref: "#/components/schemas/QuizSet"
-                        - type: object
-                          properties:
-                            quiz_set:
-                              type: array
-                              description: クイズセットの問題一覧
-                              items:
-                                allOf:
-                                  - $ref: "#/components/schemas/Quiz"
+                        - $ref: "#/components/schemas/Quiz"
+                        - $ref: "#/components/schemas/QuizAnswer"
+
+        "401":
+          description: クイズ解答失敗
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: エラーメッセージ

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -42,29 +42,29 @@ components:
         experience:
           type: integer
           description: ユーザーの経験値
-    CharacterImageId:
+    ImageId:
       type: object
       properties:
         id:
           type: string
           description: キャラクター画像のID
-    CharacterImageUrl:
-      type: object
-      properties:
-        url:
-          type: string
-          description: キャラクター画像のURL
-    CharacterImageName:
+    ImageName:
       type: object
       properties:
         name:
           type: string
           description: キャラクター画像の名前
-    CharacterImage:
+    ImageUrl:
+      type: object
+      properties:
+        url:
+          type: string
+          description: キャラクター画像のURL
+    Images:
       allOf:
-        - $ref: "#/components/schemas/CharacterImageId"
-        - $ref: "#/components/schemas/CharacterImageName"
-        - $ref: "#/components/schemas/CharacterImageUrl"
+        - $ref: "#/components/schemas/ImageId"
+        - $ref: "#/components/schemas/ImageName"
+        - $ref: "#/components/schemas/ImageUrl"
     CharacterDialogue:
       type: object
       properties:
@@ -218,16 +218,16 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
-  /home:
+  /main:
     get:
       tags:
-        - home
-      summary: ホーム画面でのデータ取得
+        - main
+      summary: メイン画面でのデータ取得
       description: ユーザのステータスや着せ替えを取得する
       parameters: []
       responses:
         "200":
-          description: ホーム画面データ取得成功
+          description: メイン画面データ取得成功
           content:
             application/json:
               schema:
@@ -238,10 +238,10 @@ paths:
                       - $ref: "#/components/schemas/UserId"
                       - $ref: "#/components/schemas/UserProfile"
                       - $ref: "#/components/schemas/UserStatus"
-                  characterImage:
+                  character:
                     allOf:
                       - $ref: "#/components/schemas/CharacterDialogue"
-                      - $ref: "#/components/schemas/CharacterImageUrl"
+                      - $ref: "#/components/schemas/ImageUrl"
               # example:
               #   user_id: "1"
               #   nickname: "ホントくん"
@@ -299,8 +299,8 @@ paths:
                       - $ref: "#/components/schemas/UserProfile"
                       - type: object
                         properties:
-                          character:
-                            $ref: "#/components/schemas/CharacterImage"
+                          costume:
+                            $ref: "#/components/schemas/Images"
                             description: ユーザの着せ替え画像
                     description: ユーザのステータス
                   history:
@@ -321,8 +321,8 @@ paths:
                             accuracy:
                               $ref: "#/components/schemas/Accuracy"
                               description: クイズセットの正答率
-                            characterImage:
-                              $ref: "#/components/schemas/CharacterImage"
+                            character:
+                              $ref: "#/components/schemas/Images"
                               description: クイズセットの指名手配猫
         "401":
           description: 認証エラー
@@ -372,7 +372,7 @@ paths:
                 type: object
                 properties:
                   character:
-                    $ref: "#/components/schemas/CharacterImage"
+                    $ref: "#/components/schemas/Images"
                     description: クイズセットの指名手配猫
                   totalAccuracy:
                     $ref: "#/components/schemas/Accuracy"
@@ -435,7 +435,7 @@ paths:
                 type: object
                 properties:
                   character:
-                    $ref: "#/components/schemas/CharacterImage"
+                    $ref: "#/components/schemas/Images"
                     description: クイズセットの指名手配猫
                   quizSet:
                     $ref: "#/components/schemas/QuizSet"
@@ -497,15 +497,25 @@ paths:
                     allOf:
                       - $ref: "#/components/schemas/UserId"
                       - $ref: "#/components/schemas/UserProfile"
-                      - type: object
-                        properties:
-                          character:
-                            $ref: "#/components/schemas/CharacterImage"
-                  characterOptions:
+                      # - type: object
+                      #   properties:
+                      #     character:
+                      #       $ref: "#/components/schemas/CharacterImage"
+                  costumeList:
                     type: array
                     description: キャラクター画像の一覧
                     items:
-                      $ref: "#/components/schemas/CharacterImage"
+                      allOf:
+                        - $ref: "#/components/schemas/Images"
+                        - type: object
+                          properties:
+                            # 持ってるかどうか
+                            isOwn:
+                              type: boolean
+                              description: ユーザが所持しているかどうか
+                            isSelected:
+                              type: boolean
+                              description: ユーザが選択しているかどうか
         "400":
           description: リクエストエラー
           content:
@@ -551,8 +561,8 @@ paths:
                 - $ref: "#/components/schemas/UserProfile"
                 - type: object
                   properties:
-                    characterId:
-                      $ref: "#/components/schemas/CharacterImageId/properties/id"
+                    costumeId:
+                      $ref: "#/components/schemas/ImageId/properties/id"
       responses:
         "200":
           description: プロフィール更新成功
@@ -564,11 +574,8 @@ paths:
                   - $ref: "#/components/schemas/UserProfile"
                   - type: object
                     properties:
-                      characterImage:
-                        $ref: "#/components/schemas/CharacterImage"
-                      message:
-                        type: string
-                        description: プロフィール更新に成功した場合に返されるメッセージ
+                      costume:
+                        $ref: "#/components/schemas/Images"
         "400":
           description: リクエストエラー
           content:
@@ -622,9 +629,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  characterImage:
-                    $ref: "#/components/schemas/CharacterImage"
+                  character:
+                    $ref: "#/components/schemas/Images"
                     description: クイズセットの指名手配猫
+                  costume:
+                    $ref: "#/components/schemas/Images"
+                    description: ユーザの着せ替え画像
                   quizSet:
                     allOf:
                       - $ref: "#/components/schemas/QuizSet"
@@ -714,6 +724,9 @@ paths:
                       allOf:
                         - $ref: "#/components/schemas/Quiz"
                         - $ref: "#/components/schemas/QuizAnswer"
+                  costume:
+                    $ref: "#/components/schemas/Images"
+                    description: ユーザの着せ替え画像
         "400":
           description: リクエストエラー
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -47,13 +47,13 @@ components:
       properties:
         id:
           type: string
-          description: ユーザーの着せ替え画像のID
+          description: キャラクター画像のID
     CharacterImageUrl:
       type: object
       properties:
         url:
           type: string
-          description: ユーザーの着せ替え画像のURL
+          description: キャラクター画像のURL
     CharacterImage:
       allOf:
         - $ref: "#/components/schemas/CharacterImageId"
@@ -72,31 +72,42 @@ components:
         dialogue:
           type: string
           description: キャラクターのセリフ
+    WantedCat:
+      allOf:
+        - $ref: "#/components/schemas/CharacterImageUrl"
+        - type: object
+          properties:
+            name:
+              type: string
+              description: 指名手配猫の名前
     Quiz:
       type: object
       properties:
-        quiz_id:
+        id:
           type: string
           description: クイズのID
-        news_title:
-          type: string
-          description: クイズのニュースのタイトル
-        news_content:
-          type: string
-          description: クイズのニュースの内容
-        news_image:
-          type: string
-          description: クイズのニュースの画像
+        news:
+          type: object
+          properties:
+            title:
+              type: string
+              description: クイズのニュースのタイトル
+            content:
+              type: string
+              description: クイズのニュースの内容
+            image:
+              type: string
+              description: クイズのニュースの画像
         question:
           type: string
           description: クイズの問題文
-        quiz_type:
+        type:
           type: string
           enum:
             - "true_or_false"
             - "multiple_choice"
           description: クイズの問題タイプ（マルバツか選択式か）
-        quiz_choices:
+        choices:
           type: array
           items:
             type: string
@@ -127,19 +138,20 @@ components:
         id:
           type: string
           description: クイズセットのID
-        difficulty:
-          type: integer
-          description: クイズセットの難易度
         accuracy:
           type: number
           format: double
-          description: クイズのセット別の正答率
+          description: クイズセットの正答率
         mode:
           type: string
           enum:
             - "battle"
             - "time_attack"
           description: クイズの出題形式（バトルかタイムアタックか）
+        answered_at:
+          type: string
+          format: date-time
+          description: クイズセットを解いた日時
 paths:
   /sign_up:
     post:
@@ -224,8 +236,8 @@ paths:
   /history:
     get:
       tags:
-        - /history
-      summary: クイズ履歴取得
+        - history
+      summary: クイズ履歴トップ取得
       description: ユーザのクイズ履歴を取得する
       parameters: []
       responses:
@@ -238,7 +250,6 @@ paths:
                 properties:
                   user:
                     allOf:
-                      # ユーザのID, name, キャラクター
                       - $ref: "#/components/schemas/UserId"
                       - $ref: "#/components/schemas/UserProfile"
                       - type: object
@@ -254,12 +265,22 @@ paths:
                         type: number
                         format: double
                         description: ユーザの総正答率
-                      quiz_set:
+                      list:
                         type: array
-                        description: クイズのセット別の一覧
+                        description: 難易度別の一覧
                         items:
-                          $ref: "#/components/schemas/QuizSet"
-
+                          type: object
+                          properties:
+                            tier:
+                              type: integer
+                              description: クイズセットの難易度
+                            accuracy:
+                              type: number
+                              format: double
+                              description: クイズセットの正答率
+                            character:
+                              $ref: "#/components/schemas/WantedCat"
+                              description: クイズセットの指名手配猫
         "401":
           description: クイズ履歴取得失敗
           content:
@@ -270,6 +291,70 @@ paths:
                   message:
                     type: string
                     description: エラーメッセージ
+  /history/tier/{tier}:
+    get:
+      tags:
+        - history
+      summary: クイズ履歴難易度別取得
+      description: ユーザのクイズ履歴のリストを難易度別に取得する
+      parameters:
+        - name: tier
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: クイズセットの難易度
+      responses:
+        "200":
+          description: クイズ履歴難易度別取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_accuracy:
+                    type: number
+                    format: double
+                    description: クイズセットの正答率
+                  quiz_set:
+                    type: array
+                    description: クイズセットの一覧
+                    items:
+                      $ref: "#/components/schemas/QuizSet"
+  /history/quiz-set/{quizSetId}:
+    get:
+      tags:
+        - history
+      summary: クイズ履歴詳細取得
+      description: ユーザのクイズ履歴の詳細を取得する
+      parameters:
+        - name: quizSetId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: クイズセットのID
+      responses:
+        "200":
+          description: クイズ履歴詳細取得成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  character:
+                    $ref: "#/components/schemas/WantedCat"
+                    description: クイズセットの指名手配猫
+                  quiz_set:
+                    $ref: "#/components/schemas/QuizSet"
+                  quizzes:
+                    type: array
+                    description: クイズの問題一覧
+                    items:
+                      allOf:
+                        - $ref: "#/components/schemas/Quiz"
+                        - $ref: "#/components/schemas/QuizUserAnswer"
+
   /profile:
     put:
       tags:
@@ -313,14 +398,14 @@ paths:
                     description: エラーメッセージ
       security:
         - bearerAuth: []
-  /quiz/{difficulty}:
+  /quiz/{tier}:
     get:
       tags:
         - quiz
       summary: クイズの問題取得
       description: クイズの問題を難易度別で取得する
       parameters:
-        - name: difficulty
+        - name: tier
           in: path
           required: true
           schema:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -150,6 +150,41 @@ components:
           type: string
           format: date-time
           description: クイズセットを解いた日時
+    BadRequestError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "リクエスト内容が無効です。入力データを確認してください。"
+          description: 入力データが不正である場合のエラーメッセージ
+    UnauthorizedError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "認証に失敗しました。再度ログインしてください。"
+          description: 認証が必要なエンドポイントに未認証のユーザがアクセスした場合のエラーメッセージ
+    ForbiddenError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "アクセスが拒否されました。権限がありません。"
+          description: ユーザがアクセス権限のないリソースにアクセスした場合のエラーメッセージ
+    NotFoundError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "リソースが見つかりません。URLが正しいか確認してください。"
+          description: リクエストされたリソースが見つからない場合のエラーメッセージ
+    InternalServerError:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "サーバーエラーが発生しました。しばらくしてから再度お試しください。"
+          description: サーバー側で予期せぬエラーが発生した場合のエラーメッセージ
 paths:
   /sign-up:
     post:
@@ -220,15 +255,29 @@ paths:
               #     僕は助手のホントくん
               #     よろしくね！"
         "401":
-          description: プロフィール取得失敗
+          description: 認証エラー
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
   /history:
     get:
       tags:
@@ -276,15 +325,29 @@ paths:
                               $ref: "#/components/schemas/CharacterImage"
                               description: クイズセットの指名手配猫
         "401":
-          description: クイズ履歴取得失敗
+          description: 認証エラー
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
       security:
         - bearerAuth: []
   /history/tier/{tier}:
@@ -319,6 +382,36 @@ paths:
                     description: クイズセットの一覧
                     items:
                       $ref: "#/components/schemas/QuizSet"
+        "400":
+          description: リクエストエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestError"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
       security:
         - bearerAuth: []
   /history/quiz-set/{quizSetId}:
@@ -353,6 +446,36 @@ paths:
                       allOf:
                         - $ref: "#/components/schemas/Quiz"
                         - $ref: "#/components/schemas/QuizAnswer"
+        "400":
+          description: リクエストエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestError"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
       security:
         - bearerAuth: []
   /profile:
@@ -383,16 +506,36 @@ paths:
                     description: キャラクター画像の一覧
                     items:
                       $ref: "#/components/schemas/CharacterImage"
-        "401":
-          description: プロフィール取得失敗
+        "400":
+          description: リクエストエラー
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
+                $ref: "#/components/schemas/BadRequestError"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
     put:
       tags:
         - profile
@@ -426,16 +569,36 @@ paths:
                       message:
                         type: string
                         description: プロフィール更新に成功した場合に返されるメッセージ
-        "401":
-          description: プロフィール更新失敗
+        "400":
+          description: リクエストエラー
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
+                $ref: "#/components/schemas/BadRequestError"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
       security:
         - bearerAuth: []
   /quiz/{tier}:
@@ -467,6 +630,36 @@ paths:
                     description: クイズのセット別の一覧
                     items:
                       $ref: "#/components/schemas/QuizSet"
+        "400":
+          description: リクエストエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestError"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"
   /quiz/result:
     post:
       tags:
@@ -510,13 +703,33 @@ paths:
                         - $ref: "#/components/schemas/Quiz"
                         - $ref: "#/components/schemas/QuizAnswer"
 
-        "401":
-          description: クイズ解答失敗
+        "400":
+          description: リクエストエラー
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: エラーメッセージ
+                $ref: "#/components/schemas/BadRequestError"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: アクセス拒否
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "404":
+          description: リソースが見つかりません
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotFoundError"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InternalServerError"


### PR DESCRIPTION
## 概要
- クイズの処理を追加
  - `/quiz/{tier}`
- クイズの結果送信の処理を追加
  - `/quiz/result`
- メイン画面でのデータ取得を各画面に分ける仕様に変更する
  - `/main`を`/main`と`/history`と`/profile`に分ける
  - `/history`は全体取得・詳細取得に分ける

## 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/1