### PR TITLE
【DB設計書】詳細なテーブル設計書を追加する

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -1,0 +1,100 @@
+# DB 設計
+
+## バックエンド
+
+### user
+
+ユーザ
+
+| カラム名     | 説明                           | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
+| ------------ | ------------------------------ | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
+| id           | ユーザ ID                      | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                | ◯      |
+| firebase_uid | Firebase Authentication の UID |     |     | VARCHAR(36) | ◯        | ◯     |         |                | ◯      |
+| nickname     | ニックネーム                   |     |     | VARCHAR(50) | ◯        |       |         |                |        |
+| birthday     | 生年月日                       |     |     | DATE        |          |       |         |                |        |
+| level        | レベル                         |     |     | INT         | ◯        |       | 0       |                |        |
+| experience   | 経験値                         |     |     | INT         | ◯        |       | 0       |                |        |
+| created_at   | 作成日時                       |     |     | DATETIME    | ◯        |       |         |                |        |
+| updated_at   | 更新日時                       |     |     | DATETIME    | ◯        |       |         |                |        |
+
+### quiz_set_log
+
+クイズセットログ
+
+| カラム名   | 説明             | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
+| ---------- | ---------------- | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
+| id         | クイズセット ID  | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                | ◯      |
+| user_id    | ユーザ ID        |     | ◯   | VARCHAR(36) | ◯        | ◯     |         |                |        |
+| mode_id    | 問題モード ID    |     | ◯   | VARCHAR(36) | ◯        |       |         |                |        |
+| created_at | 作成日時（解答） |     |     | DATETIME    | ◯        |       |         |                |        |
+| updated_at | 更新日時         |     |     | DATETIME    | ◯        |       |         |                |        |
+
+### quiz_log
+
+クイズログ
+
+| カラム名        | 説明                | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
+| --------------- | ------------------- | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
+| id              | クイズログ ID       | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                | ◯      |
+| quiz_id         | クイズ ID           |     |     | VARCHAR(36) |          |       |         |                |        |
+| quiz_set_log_id | クイズセットログ ID |     | ◯   | VARCHAR(36) | ◯        | ◯     |         |                |        |
+| user_answer     | ユーザの解答        |     |     | TEXT        | ◯        |       |         |                |        |
+| time            | 解答タイム          |     |     | INT         |          |       |         |                |        |
+| is_correct      | 正答したかどうか    |     |     | BOOLEAN     | ◯        |       |         |                |        |
+| created_at      | 作成日時            |     |     | DATETIME    | ◯        |       |         |                |        |
+| updated_at      | 更新日時            |     |     | DATETIME    | ◯        |       |         |                |        |
+
+### mode
+
+問題モード
+
+| カラム名   | 説明          | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
+| ---------- | ------------- | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
+| id         | 問題モード ID | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                |        |
+| name       | 問題モード名  |     |     | VARCHAR(50) | ◯        |       |         |                |        |
+| created_at | 作成日時      |     |     | DATETIME    | ◯        |       |         |                |        |
+
+### user_costumes
+
+ユーザが所持している着せ替え
+
+| カラム名   | 説明            | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
+| ---------- | --------------- | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
+| user_id    | ユーザ ID       | ◯   | ◯   | VARCHAR(36) | ◯        | ◯     |         |                |        |
+| costume_id | コスチューム ID | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                |        |
+| created_at | 作成日時        |     |     | DATETIME    | ◯        |       |         |                |        |
+
+---
+
+## MicroCMS
+
+### クイズ
+
+| フィールド ID | 表示名        | PK  | FK  | 型                                 | NOT NULL | default | Unique |
+| ------------- | ------------- | --- | --- | ---------------------------------- | -------- | ------- | ------ |
+|               | コンテンツ ID | ◯   |     | VARCHAR(36)                        |          |         | ◯      |
+| title         | タイトル      |     |     | VARCHAR(100)                       |          |         |        |
+| content       | 本文          |     |     | TEXT                               |          |         |        |
+| tier          | 難易度        |     |     | INT                                |          |         |        |
+| images        | 画像          |     |     | VARCHAR(255)                       |          |         |        |
+| question      | 質問文        |     |     | TEXT                               |          |         |        |
+| choices       | 選択肢        |     |     | TEXT[]                             |          |         |        |
+| type          | クイズタイプ  |     |     | ENUM(’TRUE_OR_FALSE’, ‘SELECTION’) |          |         |        |
+| answer        | 解答          |     |     | TEXT                               |          |         |        |
+| explanation   | 解説          |     |     | TEXT                               |          |         |        |
+| hint          | ヒント        |     |     | TEXT                               |          |         |        |
+| isDeleted     | 削除フラグ    |     |     | BOOLEAN                            |          | False   |        |
+| createdAt     | 作成日時      |     |     | DATETIME                           |          |         |        |
+| updatedAt     | 更新日時      |     |     | DATETIME                           |          |         |        |
+
+### ネコ
+
+| フィールド ID | 表示名        | PK  | FK  | 型                        | NOT NULL | default | Unique |
+| ------------- | ------------- | --- | --- | ------------------------- | -------- | ------- | ------ |
+|               | コンテンツ ID | ◯   |     | VARCHAR(36)               |          |         | ◯      |
+| images        | 画像          |     |     | VARCHAR(255)              |          |         |        |
+| name          | 名前          |     |     | VARCHAR(50)               |          |         |        |
+| lines         | セリフ        |     |     | TEXT[]                    |          |         |        |
+| category      | カテゴリ      |     |     | ENUM(’COSTUME’, ‘WANTED’) |          |         |        |
+| createdAt     | 作成日時      |     |     | DATETIME                  |          |         |        |
+| updatedAt     | 更新日時      |     |     | DATETIME                  |          |         |        |

--- a/docs/db.md
+++ b/docs/db.md
@@ -14,6 +14,7 @@
 | birthday     | 生年月日                       |     |     | DATE        |          |       |         |                |        |
 | level        | レベル                         |     |     | INT         | ◯        |       | 0       |                |        |
 | experience   | 経験値                         |     |     | INT         | ◯        |       | 0       |                |        |
+| costume_id   | 着せ替え ID                    |     |     | VARCHAR(36) | ◯        |       |         |                |        |
 | created_at   | 作成日時                       |     |     | DATETIME    | ◯        |       |         |                |        |
 | updated_at   | 更新日時                       |     |     | DATETIME    | ◯        |       |         |                |        |
 
@@ -36,7 +37,7 @@
 | カラム名        | 説明                | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
 | --------------- | ------------------- | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
 | id              | クイズログ ID       | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                | ◯      |
-| quiz_id         | クイズ ID           |     |     | VARCHAR(36) |          |       |         |                |        |
+| quiz_id         | クイズ ID           |     |     | VARCHAR(36) | ◯        |       |         |                |        |
 | quiz_set_log_id | クイズセットログ ID |     | ◯   | VARCHAR(36) | ◯        | ◯     |         |                |        |
 | user_answer     | ユーザの解答        |     |     | TEXT        | ◯        |       |         |                |        |
 | time            | 解答タイム          |     |     | INT         |          |       |         |                |        |
@@ -46,13 +47,12 @@
 
 ### mode
 
-問題モード
-
 | カラム名   | 説明          | PK  | FK  | 型          | NOT NULL | INDEX | default | AUTO INCREMENT | Unique |
 | ---------- | ------------- | --- | --- | ----------- | -------- | ----- | ------- | -------------- | ------ |
-| id         | 問題モード ID | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                |        |
+| id         | 問題モード ID | ◯   |     | VARCHAR(36) | ◯        | ◯     |         |                | ◯      |
 | name       | 問題モード名  |     |     | VARCHAR(50) | ◯        |       |         |                |        |
 | created_at | 作成日時      |     |     | DATETIME    | ◯        |       |         |                |        |
+| updated_at | 更新日時      |     |     | DATETIME    | ◯        |       |         |                |        |
 
 ### user_costumes
 
@@ -87,7 +87,7 @@
 | createdAt     | 作成日時      |     |     | DATETIME                           |          |         |        |
 | updatedAt     | 更新日時      |     |     | DATETIME                           |          |         |        |
 
-### ネコ
+### キャラクター
 
 | フィールド ID | 表示名        | PK  | FK  | 型                        | NOT NULL | default | Unique |
 | ------------- | ------------- | --- | --- | ------------------------- | -------- | ------- | ------ |


### PR DESCRIPTION
## 概要
- バックエンドのテーブル定義
  - [x] ユーザ
  - [x] クイズのログ
  - [x] 所持中着せ替え
  - [x] 問題モード
- MicroCMSのテーブル定義
  - [x] クイズ
  - [x] キャラクター（ネコから名前変更）
- 詳細な定義
  - [x] カラム名
  - [x] 主キー制約
  - [x] NULL制約
  - [x] INDEX
  - [x] デフォルト値
  - [x] ユニーク制約
  - [x] AUTO INCREMENT(今回はUUIDを使用するので全てなし)

## 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/2