### PR TITLE
[fix] refs 57 mysqlで日本語を扱えるようにした

### DIFF
--- a/cspell/dictionary.txt
+++ b/cspell/dictionary.txt
@@ -6,3 +6,4 @@ hono
 VARCHAR
 autoincrement
 usecase
+mysqld

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -20,6 +20,7 @@ services:
     ports:
       - 3306:3306
     volumes:
+      - ../my.cnf:/etc/mysql/conf.d/my.cnf
       - ../db-data:/var/lib/mysql
     networks:
         - hontokun

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,9 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4


### PR DESCRIPTION
### 概要
my.cnfを追加してUTF8で動作するようにした

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/57