### PR TITLE
【クイズ機能】クイズ結果の計算・ユーザデータの更新処理を追加

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,1 +1,2 @@
 export const defaultCostumeName = '探偵ネコ';
+export const MAX_EXPERIENCE = 10;

--- a/src/database/mysql/validators/quizLogValidator.ts
+++ b/src/database/mysql/validators/quizLogValidator.ts
@@ -4,9 +4,9 @@ import { quizLogTable } from '../schema/schema';
 import { idRegex } from '../../../core/regex';
 
 const quizLogSchema = {
-  id: z.string().regex(idRegex),
+  id: z.string().uuid(),
   quizId: z.string().regex(idRegex),
-  quizSetLogId: z.string().regex(idRegex),
+  quizSetLogId: z.string().uuid(),
   userAnswer: z.string(),
   isCorrect: z.boolean(),
   time: z.number().int().min(0).optional(),

--- a/src/database/mysql/validators/quizSetLogValidator.ts
+++ b/src/database/mysql/validators/quizSetLogValidator.ts
@@ -1,12 +1,11 @@
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 import { quizSetLogTable } from '../schema/schema';
-import { idRegex } from '../../../core/regex';
 
 const quizSetLogSchema = {
-  id: z.string().regex(idRegex),
-  userId: z.string().regex(idRegex),
-  quizModeId: z.string().regex(idRegex),
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  quizModeId: z.string(),
   createdAt: z.date(),
   updatedAt: z.date(),
 }

--- a/src/model/quiz/quiz.ts
+++ b/src/model/quiz/quiz.ts
@@ -1,6 +1,6 @@
 import { Choice } from './choice';
 
-type QuizParams = {
+export type QuizParams = {
   id: string;
   title: string;
   content: string;

--- a/src/model/quiz/quizLog.ts
+++ b/src/model/quiz/quizLog.ts
@@ -3,7 +3,7 @@ type QuizLog = {
   quizId: string;       // クイズID
   quizSetLogId: string; // クイズセットログID
   userAnswer: string;   // ユーザーの回答
-  time: number;         // 解答時間（秒数）
+  answerTime?: number | null;         // 解答時間（秒数）
   isCorrect: boolean;   // 正誤フラグ
   createdAt?: Date;      // 作成日時
   updatedAt?: Date;      // 更新日時

--- a/src/model/user/user.ts
+++ b/src/model/user/user.ts
@@ -1,5 +1,5 @@
 export type User = {
-  id?: string;
+  id: string;
   firebaseUid: string;
   nickname: string;
   birthday?: Date | null;

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -42,3 +42,24 @@ export const getUserByFirebaseUid = async (
 
   return user ?? null;
 };
+
+/**
+ * 経験値とレベルを更新する
+ * @param db データベースのインスタンス
+ * @param userId ユーザID
+ * @param experience 経験値
+ * @param level レベル
+ * @returns void
+ */
+export const updateUserExperience = async (
+  db: MySql2Database,
+  userId: string,
+  experience: number,
+  level: number
+): Promise<void> => {
+  await db
+    .update(usersTable)
+    .set({ experience, level })
+    .where(eq(usersTable.id, userId));
+  return;
+}

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -24,3 +24,21 @@ export const createUser = async (
 
   return validatedUser;
 }
+
+/**
+ * FirebaseUidからユーザデータを取得する
+ * @param db データベースのインスタンス
+ * @param firebaseUid FirebaseのID
+ * @returns ユーザデータ
+ */
+export const getUserByFirebaseUid = async (
+  db: MySql2Database,
+  firebaseUid: string
+): Promise<User | null> => {
+  const [user] = await db
+    .select()
+    .from(usersTable)
+    .where(eq(usersTable.firebaseUid, firebaseUid));
+
+  return user ?? null;
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,7 +60,8 @@ app.post('sign-up', async (c: Context) => {
 })
 
 app.post('/quiz/result', async (c: Context) => {
-  const userId = c.get('firebaseUid');
+  const firebaseUid = c.get('firebaseUid');
+  const user = await UserUsecase.getUserByFirebaseUid(db, firebaseUid);
   const body: paths['/quiz/result']['post']['requestBody']['content']['application/json'] = await c.req.json();
   const quizMode = quizModeSchema.parse(body.quizMode);
   const answers = body.answers!.map((data) => quizResultSchema.parse(data));

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,7 @@ app.post('/quiz/result', async (c: Context) => {
     const { quizId, answer, answerTime } = data;
     return { quizId, answer, answerTime };
   })
-  const { quizSetId, accuracy, quizList } = await QuizLogUsecase.createQuizLog(db, user.id, quizMode, quizData);
+  const { quizSetId, accuracy, quizList } = await QuizLogUsecase.createQuizLog(db, user, quizMode, quizData);
   const costume = await CostumeUsecase.getCostume(db, user.id);
 
   // TODO: 指名手配猫画像返却

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,15 +69,20 @@ app.post('/quiz/result', async (c: Context) => {
     const { quizId, answer, answerTime } = data;
     return { quizId, answer, answerTime };
   })
-  const quizList = QuizLogUsecase.createQuizLog(db, userId, quizMode, quizData);
-  const costume = await CostumeUsecase.getCostume(db, userId);
+  const { quizSetId, accuracy, quizList } = await QuizLogUsecase.createQuizLog(db, user.id, quizMode, quizData);
+  const costume = await CostumeUsecase.getCostume(db, user.id);
+
+  // TODO: 指名手配猫画像返却
 
   return c.json({
+    quizSetId,
+    accuracy,
+    quizList,
     costume: {
       id: costume.id,
       name: costume.name,
       url: costume.image.url,
-    }, quizList
+    },
   }, 200);
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,7 @@ app.post('/quiz/result', async (c: Context) => {
   const costume = await CostumeUsecase.getCostume(db, user.id);
 
   // TODO: 指名手配猫画像返却
+  const enemy = quizList[0] ? await EnemyUsecase.getQuizEnemy(db, quizList[0].tier) : null;
 
   return c.json({
     quizSetId,
@@ -83,6 +84,11 @@ app.post('/quiz/result', async (c: Context) => {
       name: costume.name,
       url: costume.image.url,
     },
+    enemy: enemy ? {
+      id: enemy.id,
+      name: enemy.name,
+      url: enemy.image.url,
+    } : null,
   }, 200);
 });
 

--- a/src/usecase/quizLog.ts
+++ b/src/usecase/quizLog.ts
@@ -2,6 +2,7 @@ import { MySql2Database } from "drizzle-orm/mysql2";
 import * as QuizRepository from "../repository/quiz";
 import * as QuizLogRepository from "../repository/quizLog";
 import * as QuizModeRepository from "../repository/quizMode";
+import { Quiz, QuizParams } from "../model/quiz/quiz";
 
 export type Answer = {
   quizId: string,
@@ -10,29 +11,52 @@ export type Answer = {
   isCorrect?: boolean,
 }
 
+export type QuizData = Quiz & Partial<Pick<QuizLog, 'userAnswer' | 'answerTime' | 'isCorrect'>>;
+
+/**
+ * クイズの回答を受け取り、ログを作成する
+ * @param db データベースのインスタンス
+ * @param userId ユーザID
+ * @param quizMode クイズモード名
+ * @param answers 解答データ
+ * @returns クイズセットID, 正答率, クイズデータのリスト
+ */
 export const createQuizLog = async (
   db: MySql2Database,
   userId: string,
   quizMode: string,
   answers: Answer[],
-): Promise<void> => {
+): Promise<{
+  quizSetId: string,
+  accuracy: number,
+  quizList: QuizParams[]
+}> => {
+  let quizList: QuizParams[] = [];
   for (const answer of answers) {
     // クイズデータをDBから取得
     const quizData = await QuizRepository.getQuizById(db, answer.quizId);
     if (!quizData) {
       throw new Error('Quiz not found');
     }
+    quizList.push({ ...quizData.toJSON() });
+    answer.isCorrect = quizData.answer === answer.answer;
 
-    // 回答が正しいか判定
-    answers.forEach((answer) => {
-      answer.isCorrect = answer.answer === quizData.answer;
-    })
-
-    // DBにログを保存
-    const modeId = await QuizModeRepository.getQuizModeId(db, quizMode);
-    const response = await QuizLogRepository.createQuizLog(db, userId, modeId, answers);
     // TODO: 正解したらポイント加算(tierの数を加算、1レベル10ポイント)
   }
-  // TODO: クイズのデータを返却
-  return;
+  // DBにログを保存
+  const modeId = await QuizModeRepository.getQuizModeId(db, quizMode);
+  const { quizSetLog, quizLogs } = await QuizLogRepository.createQuizLog(db, userId, modeId, answers);
+  quizLogs.map((log) => {
+    const quiz = quizList.find((quiz) => quiz.id === log.quizId);
+    if (quiz) {
+      Object.assign(quiz, {
+        isCorrect: log.isCorrect,
+        userAnswer: log.userAnswer,
+        answerTime: log.time,
+      })
+    }
+  });
+  const accuracy = quizLogs.filter((log) => log.isCorrect).length / quizLogs.length;
+
+  return { quizSetId: quizSetLog.id, accuracy, quizList };
 }

--- a/src/usecase/user.ts
+++ b/src/usecase/user.ts
@@ -4,7 +4,7 @@ import * as UserRepository from "../repository/user";
 import { fetchMicroCMSData } from "../core/converter/api/microcms";
 import { characters } from "../database/cms/types/response";
 import { APIError } from "../core/error";
-import { defaultCostumeName } from "../core/constants";
+import { defaultCostumeName, MAX_EXPERIENCE } from "../core/constants";
 
 export const createUser = async (
   db: MySql2Database,
@@ -45,4 +45,29 @@ export const getUserByFirebaseUid = async (
   }
 
   return user;
+}
+
+/**
+ * ユーザの経験値とレベルを更新する
+ * @param db データベースのインスタンス
+ * @param user ユーザーデータ
+ * @param tier 問題の難易度
+ * @returns void
+ */
+export const updateUserExp = async (
+  db: MySql2Database,
+  user: User,
+  tier: number,
+): Promise<void> => {
+  let newExp = user.experience + tier;
+
+  // レベルアップ判定
+  let levelUpCount = 0;
+  if (newExp >= MAX_EXPERIENCE) {
+    levelUpCount = Math.floor(newExp / MAX_EXPERIENCE);
+    newExp = newExp % MAX_EXPERIENCE
+  }
+  const newLevel = user.level + levelUpCount;
+  await UserRepository.updateUserExperience(db, user.id, newExp, newLevel);
+  return;
 }

--- a/src/usecase/user.ts
+++ b/src/usecase/user.ts
@@ -28,3 +28,21 @@ export const createUser = async (
   }
   return await UserRepository.createUser(db, user);
 }
+
+/**
+ * FirebaseUidからユーザを取得する
+ * @param db データベースのインスタンス
+ * @param firebaseUid FirebaseのユーザID
+ * @returns User
+ */
+export const getUserByFirebaseUid = async (
+  db: MySql2Database,
+  firebaseUid: string,
+): Promise<User> => {
+  const user = await UserRepository.getUserByFirebaseUid(db, firebaseUid);
+  if (!user) {
+    throw new Error('user not found');
+  }
+
+  return user;
+}


### PR DESCRIPTION
### 概要
- firebaseUidからユーザデータを取得する処理を追加
- クイズデータの返却の処理を追加
- 正解数に応じた経験値の処理を追加
  - 難易度の数値分、経験値に加算
  - 10経験値で1レベルアップ
- 指名手配猫の画像返却を追加
 
### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/14