### PR TITLE
[update] refs 76 READMEにデプロイ手順を記述した

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ npm run dev
 ```
 open http://localhost:3000
 ```
+## Installation
+create secret
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hontokun-secret
+type: Opaque
+data:
+  cms-service-domain: <microCMS-service-domain base64 encode>
+  cms-api-key: <microCMS-api-key base64 encode>
+  database-url: <databaseurl base64 encode>
+```
+apply secret
+```
+$ kubectl apply -f <secret-name>
+```
+add repositry and install
+```
+$ helm repo add hontokun-backend https://kouxi08.github.io/Hontokun-backend/
+$ helm install hontokun-backend hontokun/hontokun --create-namespace --namespace hontokun
+```


### PR DESCRIPTION
## 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/76

## 概要
KubernetesにHelmを使用してのインストール手順を記述した。

## 変更点
- READMEの修正
