### PR TITLE
【バグ修正】`ERR_SERVER_ALREADY_LISTEN`エラー修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,11 @@ import { serve } from '@hono/node-server';
 import { app } from './server.js';
 
 async function main() {
-  serve(app)
-    .listen(3000)
-    .once('listening', () => {
-      console.log('🚀 Server started on port 3000');
-    });
+  serve({
+    fetch: app.fetch,
+    port: 3000,
+  })
+  console.log('🚀 Server started on port 3000');
 }
 
 main().catch((err) => {


### PR DESCRIPTION
### 概要
- 以下を参考に修正
  - [Hono公式ドキュメント](https://hono-ja.pages.dev/docs/getting-started/nodejs#%E7%94%9F%E3%81%AE-node-js-api-%E3%81%AB%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%81%99%E3%82%8B)

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/85