### PR TITLE
corsの設定を修正

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,3 +12,8 @@ export const { MICROCMS_SERVICE_DOMAIN } = parseEnv(process.env, {
 export const { MICROCMS_API_KEY } = parseEnv(process.env, {
   MICROCMS_API_KEY: z.string().min(1),
 });
+
+export const { APP_BASE_URL } = parseEnv(process.env, {
+  APP_BASE_URL: z.string().min(1),
+});
+

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,9 +1,24 @@
 import { cors } from 'hono/cors';
+import { APP_BASE_URL } from '../config/env.js';
 
 export const corsMiddleware = () => {
   return cors({
-    origin: '*',
-    allowMethods: ['POST', 'OPTIONS'],
+    origin: [APP_BASE_URL, 'http://localhost:3000'],
+    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'Content-Type'],
     allowHeaders: ['Content-Type'],
+    exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+    maxAge: 600,
+    credentials: true,
   });
 };
+
+export const corsMiddlewareForMicroCMS = () => {
+  return cors({
+    origin: '*',
+    allowMethods: ['POST', 'OPTIONS',],
+    allowHeaders: ['Content-Type'],
+    exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],
+    maxAge: 600,
+    credentials: true,
+  })
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import {
 } from './core/validator/quizResultValidators.js';
 import type { quiz } from './database/cms/types/response';
 import { createAuthMiddleware } from './middleware/auth.js';
-import { corsMiddleware } from './middleware/cors.js';
+import { corsMiddleware, corsMiddlewareForMicroCMS } from './middleware/cors.js';
 import type { Quiz } from './model/quiz/quiz';
 import type { paths } from './openapi/schema';
 import * as CostumeUsecase from './usecase/costume.js';
@@ -33,7 +33,8 @@ const authMiddleware = createAuthMiddleware(firebaseApp);
 
 app.use(logger());
 app.use(prettyJSON());
-app.use('/webhook/quiz', corsMiddleware());
+app.use('/webhook/quiz', corsMiddlewareForMicroCMS());
+app.use(corsMiddleware());
 app.use('/sign-up', authMiddleware);
 app.use('/main', authMiddleware);
 app.use('/quiz/result', authMiddleware);


### PR DESCRIPTION
### 概要
- `/webhook/quiz`のみoriginを指定せずに許可
  - [ ] TODO: authトークン作成（今度やります）
    - [MICROCMSドキュメント - webhook](https://document.microcms.io/manual/medium-webhook-setting#:~:text=%E3%81%8C%E5%85%A5%E3%82%8A%E3%81%BE%E3%81%99%E3%80%82-,%E3%82%BB%E3%82%AD%E3%83%A5%E3%83%AA%E3%83%86%E3%82%A3%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6,-microCMS%E3%81%8B%E3%82%89%E3%81%AE)
- その他はURL指定先からのみ許可に設定