### PR TITLE
node-modulesをフロントと分ける

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+service-account-file.json
+.env*

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -2,16 +2,6 @@ FROM node:20-alpine AS base
 
 FROM base AS builder
 
-ARG cms_domain
-ARG cms_api_key
-
-
-
-ENV CMS_SERVICE_DOMAIN=${domain}
-ENV CMS_API_KEY=${api_key}
-ENV NODE_ENV=production
-
-
 WORKDIR /app
 
 COPY package*json tsconfig.json src drizzle* ./

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: docker/Dockerfile.dev
     volumes:
        - ../:/app
-       - front_node_modules:/app/node_modules
+       - back_node_modules:/app/node_modules
     networks:
       - hontokun
 
@@ -30,4 +30,4 @@ networks:
     external: true
 
 volumes:
-  front_node_modules:
+  back_node_modules:


### PR DESCRIPTION
## 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/92

## 概要
node-modulesをvolumeでフロントと共有してそうだったので別々のnode-modulesを使えるように修正
Dockerfile.prodで環境変数が必要なさそうなので削除

## 変更点
- Dockerfile.prodから環境変数を渡す部分を削除
- volumeの名称変更
- volumeのマウント場所を変更