### PR TITLE
【クイズモード】IDをintに修正

### DIFF
--- a/drizzle/0002_change_mode_id.sql
+++ b/drizzle/0002_change_mode_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `quiz_set_log` DROP FOREIGN KEY `quiz_set_log_quiz_mode_id_quiz_mode_id_fk`;
+--> statement-breakpoint
+ALTER TABLE `quiz_mode` MODIFY COLUMN `id` int AUTO_INCREMENT NOT NULL;--> statement-breakpoint
+ALTER TABLE `quiz_set_log` MODIFY COLUMN `quiz_mode_id` int NOT NULL;--> statement-breakpoint
+ALTER TABLE `quiz_set_log` ADD CONSTRAINT `quiz_set_log_quiz_mode_id_quiz_mode_id_fk` FOREIGN KEY (`quiz_mode_id`) REFERENCES `quiz_mode`(`id`) ON DELETE cascade ON UPDATE cascade;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,648 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f4bdac20-5a59-4bf5-b9ca-cc4b723a7c9e",
+  "prevId": "d8ddfeb4-3752-455f-89a5-1f84573351be",
+  "tables": {
+    "quiz_choice": {
+      "name": "quiz_choice",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_choice_quiz_id_quiz_id_fk": {
+          "name": "quiz_choice_quiz_id_quiz_id_fk",
+          "tableFrom": "quiz_choice",
+          "tableTo": "quiz",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_choice_id": {
+          "name": "quiz_choice_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "quiz_log": {
+      "name": "quiz_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quiz_set_log_id": {
+          "name": "quiz_set_log_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_answer": {
+          "name": "user_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_log_quiz_id_quiz_id_fk": {
+          "name": "quiz_log_quiz_id_quiz_id_fk",
+          "tableFrom": "quiz_log",
+          "tableTo": "quiz",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_log_quiz_set_log_id_quiz_set_log_id_fk": {
+          "name": "quiz_log_quiz_set_log_id_quiz_set_log_id_fk",
+          "tableFrom": "quiz_log",
+          "tableTo": "quiz_set_log",
+          "columnsFrom": [
+            "quiz_set_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_log_id": {
+          "name": "quiz_log_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {
+        "timeCheck": {
+          "name": "timeCheck",
+          "value": "`quiz_log`.`time` >= 0"
+        }
+      }
+    },
+    "quiz_mode": {
+      "name": "quiz_mode",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quiz_mode_id": {
+          "name": "quiz_mode_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "quiz_set_log": {
+      "name": "quiz_set_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quiz_mode_id": {
+          "name": "quiz_mode_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_set_log_user_id_users_id_fk": {
+          "name": "quiz_set_log_user_id_users_id_fk",
+          "tableFrom": "quiz_set_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_set_log_quiz_mode_id_quiz_mode_id_fk": {
+          "name": "quiz_set_log_quiz_mode_id_quiz_mode_id_fk",
+          "tableFrom": "quiz_set_log",
+          "tableTo": "quiz_mode",
+          "columnsFrom": [
+            "quiz_mode_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_set_log_id": {
+          "name": "quiz_set_log_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "quiz": {
+      "name": "quiz",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "news_url": {
+          "name": "news_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revised_at": {
+          "name": "revised_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "quiz_id": {
+          "name": "quiz_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "user_costumes": {
+      "name": "user_costumes",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "costume_id": {
+          "name": "costume_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_costumes_user_id_users_id_fk": {
+          "name": "user_costumes_user_id_users_id_fk",
+          "tableFrom": "user_costumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "level": {
+          "name": "level",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "experience": {
+          "name": "experience",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "costume_id": {
+          "name": "costume_id",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "firebase_uid": {
+          "name": "firebase_uid",
+          "columns": [
+            "firebase_uid"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_firebaseUid_unique": {
+          "name": "users_firebaseUid_unique",
+          "columns": [
+            "firebase_uid"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -14,6 +14,13 @@
       "when": 1738060608560,
       "tag": "0001_add_quiz_log_order",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1738660602414,
+      "tag": "0002_change_mode_id",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/validator/quizResultValidators.ts
+++ b/src/core/validator/quizResultValidators.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 // クイズ結果のバリデーションスキーマ
 export const quizResultSchema = z.object({
-  quizMode: z.string().min(1, { message: 'quizMode is required' }),
+  quizMode: z.number(),
   answers: z.array(
     z.object({
       quizId: z.string().min(1, { message: 'quizId is required' }),

--- a/src/database/mysql/schema/schema.ts
+++ b/src/database/mysql/schema/schema.ts
@@ -71,9 +71,9 @@ export const quizSetLogTable = mysqlTable('quiz_set_log', {
   userId: char({ length: 36 })
     .notNull()
     .references(() => usersTable.id),
-  quizModeId: char({ length: 36 })
+  quizModeId: int()
     .notNull()
-    .references(() => quizModeTable.id),
+    .references(() => quizModeTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
   ...timestamps,
 });
 
@@ -99,7 +99,7 @@ export const quizLogTable = mysqlTable(
 );
 
 export const quizModeTable = mysqlTable('quiz_mode', {
-  id: char({ length: 36 }).primaryKey(),
+  id: int().primaryKey().autoincrement(),
   name: varchar({ length: 20 }).notNull(),
   description: varchar({ length: 100 }).notNull(),
   isPublic: boolean().notNull(),

--- a/src/database/mysql/seed.ts
+++ b/src/database/mysql/seed.ts
@@ -33,11 +33,11 @@ const seedQuizModeTable = async (): Promise<void> => {
   for (const mode of modes) {
     try {
       await db.insert(quizModeTable).values(mode);
-      console.log('Success: inserted initial mode values');
     } catch (error) {
       console.error(`Error inserting mode: ${mode.name}`, error);
     }
   }
+  console.log('Success: inserted mode values');
 
 };
 

--- a/src/database/mysql/seed.ts
+++ b/src/database/mysql/seed.ts
@@ -1,4 +1,3 @@
-import { eq } from 'drizzle-orm';
 import { db } from '../../server.js';
 import { quizModeTable } from './schema/schema.js';
 
@@ -33,28 +32,8 @@ const seedQuizModeTable = async (): Promise<void> => {
 
   for (const mode of modes) {
     try {
-      // 既存データを確認
-      const existingMode = await db
-        .select()
-        .from(quizModeTable)
-        .where(eq(quizModeTable.name, mode.name))
-        .limit(1);
-
-      if (existingMode.length > 0) {
-        // データが存在する場合は update
-        await db
-          .update(quizModeTable)
-          .set({
-            description: mode.description,
-            isPublic: mode.isPublic,
-          })
-          .where(eq(quizModeTable.name, mode.name));
-        console.log('success: updated mode values');
-      } else {
-        // データが存在しない場合は insert
-        await db.insert(quizModeTable).values(mode);
-        console.log('success: inserted initial mode values');
-      }
+      await db.insert(quizModeTable).values(mode);
+      console.log('Success: inserted initial mode values');
     } catch (error) {
       console.error(`Error inserting mode: ${mode.name}`, error);
     }

--- a/src/database/mysql/validators/quizSetLogValidator.ts
+++ b/src/database/mysql/validators/quizSetLogValidator.ts
@@ -5,7 +5,7 @@ import { quizSetLogTable } from '../schema/schema.js';
 const quizSetLogSchema = {
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  quizModeId: z.string(),
+  quizModeId: z.number(),
   createdAt: z.date(),
   updatedAt: z.date(),
 };

--- a/src/model/quiz/quizSetLog.ts
+++ b/src/model/quiz/quizSetLog.ts
@@ -1,7 +1,7 @@
 type QuizSetLog = {
   id: string; // クイズセットログID
   userId: string; // ユーザーID
-  quizModeId: string; // クイズモードID
+  quizModeId: number; // クイズモードID
   createdAt?: Date; // 作成日時
   updatedAt?: Date; // 更新日時
 };

--- a/src/repository/quizLog.ts
+++ b/src/repository/quizLog.ts
@@ -34,7 +34,7 @@ export const getSolvedQuizIds = async (
 export const createQuizLog = async (
   db: MySql2Database,
   userId: string,
-  quizModeId: string,
+  quizModeId: number,
   answers: Answer[]
 ): Promise<{
   quizSetLog: InsertQuizSetLogType;

--- a/src/repository/quizMode.ts
+++ b/src/repository/quizMode.ts
@@ -11,7 +11,7 @@ import { quizModeTable } from '../database/mysql/schema/schema.js';
 export const getQuizModeId = async (
   db: MySql2Database,
   mode: string
-): Promise<string> => {
+): Promise<number> => {
   const data = await db
     .select({ id: quizModeTable.id })
     .from(quizModeTable)
@@ -32,7 +32,7 @@ export const getQuizModeId = async (
  */
 export const getQuizModeName = async (
   db: MySql2Database,
-  id: string
+  id: number
 ): Promise<string> => {
   const data = await db
     .select({ name: quizModeTable.name })

--- a/src/usecase/quizLog.ts
+++ b/src/usecase/quizLog.ts
@@ -30,7 +30,7 @@ export type QuizData = Quiz &
 export const createQuizLog = async (
   db: MySql2Database,
   user: User,
-  quizModeId: string,
+  quizModeId: number,
   answers: Answer[]
 ) => {
   const quizList: QuizParams[] = [];


### PR DESCRIPTION
### 概要
- `quiz_mode`テーブルの`id`のスキーマを変更

### DBのスキーマ変更手順
※ ログ消えます
1. mysqlログインした後
  ```
  DELETE FROM quiz_set_log;
  DELETE FROM quiz_log;
  DELETE FROM quiz_mode;

  ```
2. `make app-shell`したあと
  ```
  npm run drizzle:push
  npm run drizzle:seed

  ```

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/122