### PR TITLE
[update] refs 89 originの値を変更

### DIFF
--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -2,7 +2,7 @@ import { cors } from 'hono/cors';
 
 export const corsMiddleware = () => {
   return cors({
-    origin: [process.env.APP_BASE_URL!, 'http://localhost:8080'],
+    origin: ['https://hontokun.kouxi.jp', 'http://localhost:8080'],
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'Content-Type'],
     allowHeaders: ['Content-Type', 'authorization'],
     exposeHeaders: ['Content-Length', 'X-Kuma-Revision'],


### PR DESCRIPTION
## 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/90

## 概要
corsの値を環境変数から参照するのではなく、直接読み込むように変更した

## 変更点
- cors.tsのoriginを変更した