### PR TITLE
【履歴】正答率の計算処理を修正

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,6 @@ import * as QuizUsecase from './usecase/quiz.js';
 import * as EnemyUsecase from './usecase/enemy.js';
 import * as QuizLogUsecase from './usecase/quizLog.js';
 import * as UserUsecase from './usecase/user.js';
-import type { History } from './types/api/history';
 import { zValidator } from '@hono/zod-validator';
 import { Variables } from './core/variables.js';
 import { formatDate } from './core/formatDate.js';
@@ -182,21 +181,7 @@ app.get('/history', async (c: Context) => {
   const firebaseUid = c.get('firebaseUid');
   const user = await UserUsecase.getUserByFirebaseUid(db, firebaseUid);
   const costume = await CostumeUsecase.getCostume(db, user.id);
-
-  const history: History = {};
-  const logs = await QuizLogUsecase.getAllQuizLog(db, user.id);
-  let totalAccuracy = 0;
-  history.tierList = await Promise.all(
-    logs.map(async (log) => {
-      const enemy = await EnemyUsecase.getQuizEnemy(db, log.tier);
-      totalAccuracy += log.accuracy;
-      return {
-        ...log,
-        enemy,
-      };
-    })
-  );
-  history.totalAccuracy = totalAccuracy / logs.length;
+  const history = await QuizLogUsecase.getAllQuizLog(db, user.id);
 
   return c.json(
     {
@@ -210,7 +195,7 @@ app.get('/history', async (c: Context) => {
           url: costume.image.url,
         },
       },
-      history,
+      ...history,
     },
     200
   );

--- a/src/types/api/history.ts
+++ b/src/types/api/history.ts
@@ -1,4 +1,0 @@
-import type { paths } from '../../openapi/schema';
-
-export type History =
-  paths['/history']['get']['responses']['200']['content']['application/json']['history'];


### PR DESCRIPTION
### 概要
- GET `/history`のaccuracy, totalAccuracyの計算修正
- enemy取得の処理usecaseに移動

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/130