### PR TITLE
【クイズ結果】解答時間を任意入力に修正

### DIFF
--- a/src/core/validator/quizResultValidators.ts
+++ b/src/core/validator/quizResultValidators.ts
@@ -11,7 +11,8 @@ export const quizResultSchema = z.object({
       answerTime: z
         .number()
         .int()
-        .nonnegative({ message: 'answerTime must be a non-negative integer' }),
+        .nonnegative({ message: 'answerTime must be a non-negative integer' })
+        .optional(),
     })
   ),
 });

--- a/src/usecase/quizLog.ts
+++ b/src/usecase/quizLog.ts
@@ -12,7 +12,7 @@ export type Answer = {
   quizId: string;
   order: number;
   answer: string;
-  answerTime: number;
+  answerTime?: number;
   isCorrect?: boolean;
 };
 


### PR DESCRIPTION
### 概要
- `/quiz/result`で`answerTime`を任意入力に修正

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/131