### PR TITLE
【プロフィール】きせかえとプロフィールの取得追加

### DIFF
--- a/cspell/dictionary.txt
+++ b/cspell/dictionary.txt
@@ -8,3 +8,4 @@ autoincrement
 usecase
 mysqld
 microcms
+uaa4ulkf65hj989lftimm02bgt68umhre_9f

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_COSTUME_NAME = '探偵ネコ';
+export const DEFAULT_COSTUME_ID = 'uaa4ulkf65hj989lftimm02bgt68umhre_9f';
 export const MAX_EXPERIENCE = 10;
 export const MAX_TIER = 5;

--- a/src/database/mysql/schema/schema.ts
+++ b/src/database/mysql/schema/schema.ts
@@ -73,7 +73,10 @@ export const quizSetLogTable = mysqlTable('quiz_set_log', {
     .references(() => usersTable.id),
   quizModeId: int()
     .notNull()
-    .references(() => quizModeTable.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    .references(() => quizModeTable.id, {
+      onDelete: 'cascade',
+      onUpdate: 'cascade',
+    }),
   ...timestamps,
 });
 

--- a/src/database/mysql/seed.ts
+++ b/src/database/mysql/seed.ts
@@ -38,7 +38,6 @@ const seedQuizModeTable = async (): Promise<void> => {
     }
   }
   console.log('Success: inserted mode values');
-
 };
 
 seedQuizModeTable()

--- a/src/database/mysql/seed.ts
+++ b/src/database/mysql/seed.ts
@@ -1,5 +1,11 @@
+import { and, eq } from 'drizzle-orm';
+import { DEFAULT_COSTUME_ID } from '../../core/constants.js';
 import { db } from '../../server.js';
-import { quizModeTable } from './schema/schema.js';
+import {
+  quizModeTable,
+  userCostumesTable,
+  usersTable,
+} from './schema/schema.js';
 
 const seedQuizModeTable = async (): Promise<void> => {
   const modes = [
@@ -32,7 +38,16 @@ const seedQuizModeTable = async (): Promise<void> => {
 
   for (const mode of modes) {
     try {
+      const exists = await db
+        .select()
+        .from(quizModeTable)
+        .where(eq(quizModeTable.name, mode.name));
+      if (exists.length > 0) {
+        console.log(`Mode ${mode.name} already exists, skipping...`);
+        continue;
+      }
       await db.insert(quizModeTable).values(mode);
+      console.log(`Inserted mode: ${mode.name}`);
     } catch (error) {
       console.error(`Error inserting mode: ${mode.name}`, error);
     }
@@ -40,9 +55,42 @@ const seedQuizModeTable = async (): Promise<void> => {
   console.log('Success: inserted mode values');
 };
 
-seedQuizModeTable()
-  .then(() => process.exit(0))
-  .catch((err) => {
-    console.error('Error inserting mode values:', err);
-    process.exit(1);
-  });
+/**
+ * デフォルトのきせかえ情報をユーザに紐付ける
+ */
+const seedUserCostumeTable = async (): Promise<void> => {
+  const costumeId = DEFAULT_COSTUME_ID;
+  const userIds = await db.select({ id: usersTable.id }).from(usersTable);
+  for (const user of userIds) {
+    const exists = await db
+      .select()
+      .from(userCostumesTable)
+      .where(
+        and(
+          eq(userCostumesTable.userId, user.id),
+          eq(userCostumesTable.costumeId, costumeId)
+        )
+      );
+    if (exists.length === 0) {
+      await db.insert(userCostumesTable).values({
+        userId: user.id,
+        costumeId,
+      });
+    }
+  }
+  console.log('Success: inserted user costume values');
+};
+
+const main = async () => {
+  try {
+    await seedQuizModeTable();
+    await seedUserCostumeTable();
+    console.log('Seeding completed successfully.');
+  } catch (error) {
+    console.error('Seeding failed:', error);
+  } finally {
+    process.exit(0);
+  }
+};
+
+main();

--- a/src/repository/costume.ts
+++ b/src/repository/costume.ts
@@ -1,6 +1,9 @@
 import { eq } from 'drizzle-orm';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
-import { usersTable } from '../database/mysql/schema/schema.js';
+import {
+  userCostumesTable,
+  usersTable,
+} from '../database/mysql/schema/schema.js';
 
 export const getCostumeId = async (
   db: MySql2Database,
@@ -14,4 +17,21 @@ export const getCostumeId = async (
     throw new Error('costume id is not found');
   }
   return costumeId[0].costumeId!;
+};
+
+/**
+ * ユーザが所持しているきせかえIDを取得する
+ * @param db データベースのインスタンス
+ * @param userId ユーザID
+ * @returns きせかえIDの配列
+ */
+export const getOwnedCostumeIds = async (
+  db: MySql2Database,
+  userId: string
+): Promise<string[]> => {
+  const costumeIds = await db
+    .select({ costumeId: userCostumesTable.costumeId })
+    .from(userCostumesTable)
+    .where(eq(userCostumesTable.userId, userId));
+  return costumeIds.map((costume) => costume.costumeId!);
 };

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -2,6 +2,8 @@ import { eq } from 'drizzle-orm';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
 import { AuthError } from '../core/error.js';
 import {
+  quizLogTable,
+  quizSetLogTable,
   userCostumesTable,
   usersTable,
 } from '../database/mysql/schema/schema.js';
@@ -70,5 +72,32 @@ export const updateUserExperience = async (
     .update(usersTable)
     .set({ experience, level })
     .where(eq(usersTable.id, userId));
+  return;
+};
+
+/**
+ * ユーザを削除する
+ * @param db データベースのインスタンス
+ * @param userId ユーザID
+ * @returns
+ */
+export const deleteUser = async (db: MySql2Database, userId: string) => {
+  await db.transaction(async (trx) => {
+    const setLogs = await trx
+      .select({ id: quizSetLogTable.id })
+      .from(quizSetLogTable)
+      .where(eq(quizSetLogTable.userId, userId));
+    if (setLogs.length > 0) {
+      for (const setLog of setLogs) {
+        await trx
+          .delete(quizLogTable)
+          .where(eq(quizLogTable.quizSetLogId, setLog.id));
+      }
+      await trx
+        .delete(quizSetLogTable)
+        .where(eq(quizSetLogTable.userId, userId));
+    }
+    await trx.delete(usersTable).where(eq(usersTable.id, userId));
+  });
   return;
 };

--- a/src/repository/user.ts
+++ b/src/repository/user.ts
@@ -1,7 +1,10 @@
 import { eq } from 'drizzle-orm';
 import type { MySql2Database } from 'drizzle-orm/mysql2';
 import { AuthError } from '../core/error.js';
-import { usersTable } from '../database/mysql/schema/schema.js';
+import {
+  userCostumesTable,
+  usersTable,
+} from '../database/mysql/schema/schema.js';
 import { insertUserSchema } from '../database/mysql/validators/userValidator.js';
 import type { User } from '../model/user/user';
 
@@ -20,7 +23,13 @@ export const createUser = async (
     throw new AuthError('User already exists');
   }
 
-  await db.insert(usersTable).values(validatedUser);
+  db.transaction(async (db) => {
+    await db.insert(usersTable).values(validatedUser);
+    await db.insert(userCostumesTable).values({
+      userId: validatedUser.id,
+      costumeId: validatedUser.costumeId,
+    });
+  });
 
   return validatedUser;
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -139,10 +139,10 @@ app.post('/quiz/result', zValidator('json', quizResultSchema), async (c) => {
       },
       enemy: enemy
         ? {
-          id: enemy.id,
-          name: enemy.name,
-          url: enemy.image.url,
-        }
+            id: enemy.id,
+            name: enemy.name,
+            url: enemy.image.url,
+          }
         : null,
     },
     200
@@ -284,12 +284,17 @@ app.post('/webhook/quiz', async (c: Context) => {
 app.get('/profile', async (c) => {
   const firebaseUid = c.get('firebaseUid');
   const user = await UserUsecase.getUserByFirebaseUid(db, firebaseUid);
+  const costumeList = await CostumeUsecase.getAllCostume(db, user);
 
-  return c.json({
-    profile: {
-      id: user.id,
-      nickname: user.nickname,
-      birthday: user.birthday,
-    }
-  }, 200);
+  return c.json(
+    {
+      profile: {
+        id: user.id,
+        nickname: user.nickname,
+        birthday: user.birthday,
+      },
+      costumeList,
+    },
+    200
+  );
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ app.use('/sign-up', authMiddleware);
 app.use('/main', authMiddleware);
 app.use('/quiz/result', authMiddleware);
 app.use('/history', authMiddleware);
+app.use('/profile', authMiddleware);
 app.use('/quiz/:tier', authMiddleware);
 app.use('/history/quiz-set/:quizSetId', authMiddleware);
 
@@ -138,10 +139,10 @@ app.post('/quiz/result', zValidator('json', quizResultSchema), async (c) => {
       },
       enemy: enemy
         ? {
-            id: enemy.id,
-            name: enemy.name,
-            url: enemy.image.url,
-          }
+          id: enemy.id,
+          name: enemy.name,
+          url: enemy.image.url,
+        }
         : null,
     },
     200
@@ -278,4 +279,17 @@ app.post('/webhook/quiz', async (c: Context) => {
   }
 
   return c.json({ message: 'Success' }, 200);
+});
+
+app.get('/profile', async (c) => {
+  const firebaseUid = c.get('firebaseUid');
+  const user = await UserUsecase.getUserByFirebaseUid(db, firebaseUid);
+
+  return c.json({
+    profile: {
+      id: user.id,
+      nickname: user.nickname,
+      birthday: user.birthday,
+    }
+  }, 200);
 });

--- a/src/usecase/costume.ts
+++ b/src/usecase/costume.ts
@@ -3,6 +3,7 @@ import { fetchMicroCMSData } from '../core/converter/api/microcms.js';
 import type { characters } from '../database/cms/types/response';
 import { Costume } from '../model/character/costume.js';
 import * as CostumeRepository from '../repository/costume.js';
+import { User } from '../model/user/user.js';
 
 /**
  * 着せ替えのデータを取得する関数
@@ -34,5 +35,31 @@ export const getCostume = async (
     updatedAt: new Date(costume.updatedAt),
     publishedAt: new Date(costume.publishedAt),
     revisedAt: new Date(costume.revisedAt),
+  });
+};
+
+/**
+ * コスチュームをすべて取得する（所持・選択フラグを追加）
+ * @param db データベースのインスタンス
+ * @param user ユーザーデータ
+ */
+export const getAllCostume = async (db: MySql2Database, user: User) => {
+  const costumes = await fetchMicroCMSData<characters<'get'>[]>('characters', {
+    filters: 'category[contains]costume',
+  });
+  const selectedCostumeId = await CostumeRepository.getCostumeId(db, user.id);
+  const ownedCostumeIds = await CostumeRepository.getOwnedCostumeIds(
+    db,
+    user.id
+  );
+
+  return costumes.map((costume) => {
+    return {
+      id: costume.id,
+      name: costume.name,
+      url: costume.image.url,
+      isSelected: selectedCostumeId === costume.id,
+      isOwned: ownedCostumeIds.includes(costume.id),
+    };
   });
 };


### PR DESCRIPTION
### 概要
- GET `/profile`を追加
- `sign-up`でデフォルトのきせかえを`user_costume`テーブル（所持きせかえ一覧）に追加するのを忘れていたので修正
- seedの修正
  - デフォルトのきせかえがユーザに紐づいていない（所持していないことになってる）場合はinsertするように修正
  - モードのほうもnameが重複していたらinsertしないように修正

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/15