### PR TITLE
【クイズ履歴】難易度別の正解率を修正

### DIFF
--- a/src/usecase/quizLog.ts
+++ b/src/usecase/quizLog.ts
@@ -183,7 +183,7 @@ export const getAllQuizLog = async (db: MySql2Database, userId: string) => {
         (sum, quizSet) => sum + quizSet.accuracy,
         0
       );
-      tierData.accuracy = totalTierAccuracy / tierData.quizSetList.length;
+      tierData.accuracy = Math.floor(totalTierAccuracy / tierData.quizSetList.length);
     }
   }
 


### PR DESCRIPTION
### 概要
- 難易度別正解率を小数点以下丸める
![hontokun kouxi jp_profile(iPhone 12 Pro)](https://github.com/user-attachments/assets/1ed3dbe9-74ef-457d-9681-f3891616f191)

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/144