### PR TITLE
【クイズ取得】correctAnswer修正

### DIFF
--- a/src/usecase/quiz.ts
+++ b/src/usecase/quiz.ts
@@ -90,7 +90,7 @@ export const getQuizzes = async (
           choice: choice.name,
         };
       }),
-      correctAnswer: quiz.answer == true ? 'TRUE' : quiz.answer == false ? 'FALSE' : quiz.answer,
+      correctAnswer: quiz.answer,
       hint: quiz.hint,
       keyword: quiz.keyword,
     };


### PR DESCRIPTION
### 概要
- `correctAnswer`を文字列で返していたので修正

### 関連issue
- https://github.com/kouxi08/Hontokun-backend/issues/147