### PR TITLE
【きせかえ】レベルアップでゲット

### DIFF
--- a/src/database/cms/schema/api-characters-20250220234138.json
+++ b/src/database/cms/schema/api-characters-20250220234138.json
@@ -28,6 +28,13 @@
       "kind": "number",
       "description": "※敵キャラクターのみ",
       "numberSizeLimitValidation": { "numberSize": { "min": 1, "max": 5 } }
+    },
+    {
+      "fieldId": "level",
+      "name": "獲得レベル",
+      "kind": "number",
+      "description": "きせかえの獲得レベルを入力してください",
+      "numberSizeLimitValidation": { "numberSize": { "min": 1, "max": null } }
     }
   ],
   "customFields": []

--- a/src/database/cms/types/response.ts
+++ b/src/database/cms/types/response.ts
@@ -98,6 +98,10 @@ export type characters<T = 'get'> = Structure<
      * 難易度
      */
     tier?: number;
+    /**
+     * 獲得レベル
+     */
+    level?: number;
   }
 >;
 

--- a/src/repository/costume.ts
+++ b/src/repository/costume.ts
@@ -54,3 +54,20 @@ export const updateCostumeId = async (
     .where(eq(usersTable.id, userId));
   return;
 };
+
+/**
+ * ユーザが所持する着せ替えを追加する
+ * @param db データベースのインスタンス
+ * @param userId ユーザID
+ * @param costumeId コスチュームID
+ * @returns 
+ */
+export const addCostume = async (
+  db: MySql2Database,
+  userId: string,
+  costumeId: string
+) => {
+  return await db
+    .insert(userCostumesTable)
+    .values({ userId, costumeId });
+}

--- a/src/repository/costume.ts
+++ b/src/repository/costume.ts
@@ -60,14 +60,12 @@ export const updateCostumeId = async (
  * @param db データベースのインスタンス
  * @param userId ユーザID
  * @param costumeId コスチュームID
- * @returns 
+ * @returns
  */
 export const addCostume = async (
   db: MySql2Database,
   userId: string,
   costumeId: string
 ) => {
-  return await db
-    .insert(userCostumesTable)
-    .values({ userId, costumeId });
-}
+  return await db.insert(userCostumesTable).values({ userId, costumeId });
+};

--- a/src/usecase/quiz.ts
+++ b/src/usecase/quiz.ts
@@ -26,13 +26,13 @@ export const updateQuiz = async (
 const mapQuizData = (quiz: quiz<'get'>): Quiz => {
   const choices = quiz.choices
     ? quiz.choices!.split('\n').map((choice) => {
-      return Choice.create({
-        id: null,
-        name: choice,
-        createdAt: new Date(quiz.createdAt),
-        updatedAt: new Date(quiz.updatedAt),
-      });
-    })
+        return Choice.create({
+          id: null,
+          name: choice,
+          createdAt: new Date(quiz.createdAt),
+          updatedAt: new Date(quiz.updatedAt),
+        });
+      })
     : [];
 
   return Quiz.create({

--- a/src/usecase/quizLog.ts
+++ b/src/usecase/quizLog.ts
@@ -181,14 +181,20 @@ export const getAllQuizLog = async (db: MySql2Database, userId: string) => {
   // 難易度ごとの正答率を計算
   for (const tierData of response) {
     // answeredAtを降順にソート
-    tierData.quizSetList.sort((a, b) => new Date(b.answeredAtISO).getTime() - new Date(a.answeredAtISO).getTime());
+    tierData.quizSetList.sort(
+      (a, b) =>
+        new Date(b.answeredAtISO).getTime() -
+        new Date(a.answeredAtISO).getTime()
+    );
 
     if (tierData.quizSetList.length > 0) {
       const totalTierAccuracy = tierData.quizSetList.reduce(
         (sum, quizSet) => sum + quizSet.accuracy,
         0
       );
-      tierData.accuracy = Math.floor(totalTierAccuracy / tierData.quizSetList.length);
+      tierData.accuracy = Math.floor(
+        totalTierAccuracy / tierData.quizSetList.length
+      );
     }
   }
 

--- a/src/usecase/user.ts
+++ b/src/usecase/user.ts
@@ -74,6 +74,16 @@ export const updateUserExp = async (
   }
   const newLevel = user.level + levelUpCount;
   await UserRepository.updateUserExperience(db, user.id, newExp, newLevel);
+
+  // レベルが上がっていたら新しいきせかえを追加
+  if (levelUpCount > 0) {
+    const costume = await fetchMicroCMSData<characters<'get'>[]>('characters', {
+      filters: `level[equals]${newLevel}`,
+    });
+    if (costume[0]) {
+      await CostumeRepository.addCostume(db, user.id, costume[0].id);
+    }
+  }
   return;
 };
 


### PR DESCRIPTION
### 概要
- MicroCMSのきせかえのデータに何レベルでゲットするかの項目を追加(level)
- きせかえ処理を追加（クイズ結果送信→ユーザの経験値アップ→レベルアップ時のみ）

### 関連issue
- #161 